### PR TITLE
Fix Prisma schema validation errors by installing OpenSSL in builder …

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -19,6 +19,10 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Set a temporary database path for build
 ENV DATABASE_PATH=/tmp/build.db
 ENV DATABASE_URL=file:/tmp/build.db
+# Install openssl for Prisma query engine
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssl \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 # Build the application (includes prisma generate as per Prisma best practices)


### PR DESCRIPTION
…stage

The build was failing during 'prisma generate' with numerous validation errors because Prisma's query engine requires OpenSSL to function properly. The builder stage was missing the openssl package, causing the engine to fail to load and produce cryptic parsing errors.

This adds openssl installation to the builder stage, matching what was already present in the runner stage.