### PR TITLE
Fix Prisma client generation in Docker build following best practices

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -13,9 +13,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json* ./
-# Copy prisma schema before npm ci so postinstall can generate if needed
+# Copy prisma schema before npm ci so postinstall can generate
 COPY prisma ./prisma
+# Set temporary DATABASE_URL for Prisma CLI
+ENV DATABASE_URL=file:/tmp/dev.db
+# Install dependencies (postinstall will run prisma generate)
 RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+# Explicitly verify Prisma client is generated
+RUN npx prisma generate
 
 FROM base AS builder
 ENV NODE_ENV=production
@@ -29,9 +34,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-# Build the application (prisma client already generated in deps stage with engines)
-# Use db push to create schema without regenerating client
-RUN npx prisma db push --skip-generate
+# Generate Prisma client (ensures it's available in this stage)
+RUN npx prisma generate
+# Push schema to temporary database for build-time data access
+RUN npx prisma db push
+# Build the Next.js application
 RUN npm run build && rm -f /tmp/build.db
 
 FROM base AS runner

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "postinstall": "prisma generate || echo 'Prisma generate skipped'"
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
Following the Prisma guide for GitHub Actions and CI/CD, this commit addresses the Prisma client generation issues in the Docker build process:

Changes:
1. **package.json**:
   - Removed silent failure fallback in postinstall hook
   - Removed redundant prisma generate from build script
   - Now fails fast if Prisma generation has issues

2. **docker/web/Dockerfile**:
   - Added DATABASE_URL environment variable in deps stage
   - Explicitly run prisma generate after npm install to ensure client is created
   - Generate Prisma client again in builder stage for build context
   - Removed --skip-generate flag from prisma db push
   - Added clear comments explaining each Prisma-related step

These changes ensure:
- Prisma client is generated with correct engines for debian-openssl-3.0.x
- Build fails early if there are Prisma configuration issues
- DATABASE_URL is set before running any Prisma commands
- Proper multi-stage Docker build with Prisma support