### PR TITLE
fix: UDP L4 proxy routing — use udp/ prefix for listen addresses

### DIFF
--- a/src/lib/caddy.ts
+++ b/src/lib/caddy.ts
@@ -1320,17 +1320,25 @@ async function buildL4Servers(): Promise<Record<string, unknown> | null> {
     getGeoBlockSettings(),
   ]);
 
-  // Group hosts by listen address — multiple hosts on the same port share routes in one server
+  const formatListenAddress = (protocol: string, listenAddress: string) => {
+    if (protocol === "udp") {
+      return listenAddress.startsWith("udp/") ? listenAddress : `udp/${listenAddress}`;
+    }
+    return listenAddress;
+  };
+
+  // Group hosts by protocol + listen address — TCP and UDP on the same port get separate servers
   const serverMap = new Map<string, typeof l4Hosts>();
   for (const host of l4Hosts) {
-    const key = host.listenAddress;
+    const key = `${host.protocol}:${host.listenAddress}`;
     if (!serverMap.has(key)) serverMap.set(key, []);
     serverMap.get(key)!.push(host);
   }
 
   const servers: Record<string, unknown> = {};
   let serverIdx = 0;
-  for (const [listenAddr, hosts] of serverMap) {
+  for (const [, hosts] of serverMap) {
+    const listenAddr = formatListenAddress(hosts[0].protocol, hosts[0].listenAddress);
     const routes: Record<string, unknown>[] = [];
 
     for (const host of hosts) {
@@ -1441,7 +1449,7 @@ async function buildL4Servers(): Promise<Record<string, unknown> | null> {
 
       const proxyHandler: Record<string, unknown> = {
         handler: "proxy",
-        upstreams: resolvedDials.map((u) => ({ dial: [u] })),
+        upstreams: resolvedDials.map((u) => ({ dial: [formatListenAddress(host.protocol, u)] })),
       };
       if (host.proxyProtocolVersion) {
         proxyHandler.proxy_protocol = host.proxyProtocolVersion;

--- a/tests/integration/l4-caddy-config.test.ts
+++ b/tests/integration/l4-caddy-config.test.ts
@@ -48,16 +48,24 @@ function buildExpectedL4Config(rows: (typeof l4ProxyHosts.$inferSelect)[]) {
   const enabledRows = rows.filter(r => r.enabled);
   if (enabledRows.length === 0) return null;
 
+  const formatListenAddress = (protocol: string, address: string) => {
+    if (protocol === 'udp') {
+      return address.startsWith('udp/') ? address : `udp/${address}`;
+    }
+    return address;
+  };
+
   const serverMap = new Map<string, typeof enabledRows>();
   for (const host of enabledRows) {
-    const key = host.listenAddress;
+    const key = `${host.protocol}:${host.listenAddress}`;
     if (!serverMap.has(key)) serverMap.set(key, []);
     serverMap.get(key)!.push(host);
   }
 
   const servers: Record<string, unknown> = {};
   let serverIdx = 0;
-  for (const [listenAddr, hosts] of serverMap) {
+  for (const [, hosts] of serverMap) {
+    const listenAddr = formatListenAddress(hosts[0].protocol, hosts[0].listenAddress);
     const routes = hosts.map(host => {
       const route: Record<string, unknown> = {};
       const matcherValues = host.matcherValue ? JSON.parse(host.matcherValue) as string[] : [];
@@ -77,7 +85,7 @@ function buildExpectedL4Config(rows: (typeof l4ProxyHosts.$inferSelect)[]) {
       const upstreams = JSON.parse(host.upstreams) as string[];
       const proxyHandler: Record<string, unknown> = {
         handler: 'proxy',
-        upstreams: upstreams.map(u => ({ dial: [u] })),
+        upstreams: upstreams.map(u => ({ dial: [formatListenAddress(host.protocol, u)] })),
       };
       if (host.proxyProtocolVersion) proxyHandler.proxy_protocol = host.proxyProtocolVersion;
 
@@ -351,8 +359,58 @@ describe('L4 Caddy config generation', () => {
     const rows = await db.select().from(l4ProxyHosts);
     const config = buildExpectedL4Config(rows)!;
     const server = config.l4_server_0 as any;
-    expect(server.listen).toEqual([':5353']);
-    expect(server.routes[0].handle[0].upstreams).toHaveLength(2);
+    expect(server.listen).toEqual(['udp/:5353']);
+    expect(server.routes[0].handle[0].upstreams).toEqual([
+      { dial: ['udp/8.8.8.8:53'] },
+      { dial: ['udp/8.8.4.4:53'] },
+    ]);
+  });
+
+  it('same port with different protocols creates separate servers', async () => {
+    // DNS (port 5353) is a real-world case where both TCP and UDP share a port —
+    // this test ensures the grouping key includes protocol so they get separate servers.
+    await insertL4Host({
+      name: 'DNS TCP',
+      protocol: 'tcp',
+      listenAddress: ':5353',
+      upstreams: JSON.stringify(['10.0.0.1:5353']),
+    });
+    await insertL4Host({
+      name: 'DNS UDP',
+      protocol: 'udp',
+      listenAddress: ':5353',
+      upstreams: JSON.stringify(['10.0.0.2:5353']),
+    });
+
+    const rows = await db.select().from(l4ProxyHosts);
+    const config = buildExpectedL4Config(rows)!;
+
+    const servers = Object.values(config) as any[];
+    expect(servers).toHaveLength(2);
+
+    const tcpServer = servers.find(s => s.listen?.[0] === ':5353');
+    const udpServer = servers.find(s => s.listen?.[0] === 'udp/:5353');
+
+    expect(tcpServer).toEqual({
+      listen: [':5353'],
+      routes: [
+        {
+          handle: [
+            { handler: 'proxy', upstreams: [{ dial: ['10.0.0.1:5353'] }] },
+          ],
+        },
+      ],
+    });
+    expect(udpServer).toEqual({
+      listen: ['udp/:5353'],
+      routes: [
+        {
+          handle: [
+            { handler: 'proxy', upstreams: [{ dial: ['udp/10.0.0.2:5353'] }] },
+          ],
+        },
+      ],
+    });
   });
 
   it('TLS SNI with multiple hostnames', async () => {


### PR DESCRIPTION
UDP currently non-functional at L4 Proxy Hosts

<img width="943" height="712" alt="image" src="https://github.com/user-attachments/assets/be78b9fa-4a2b-4f65-877f-5ffdab9ddb50" />

![gif](https://github.com/user-attachments/assets/d1d1f3e9-6283-4635-b7db-d5fa1397c6c9)

When a UDP L4 proxy host is saved, buildL4Servers() was generating a listen address of :PORT (no network prefix), which Caddy treats as TCP by default. UDP hosts were silently proxied over TCP.

Per the Caddy network address spec [1], omitting the network prefix defaults to TCP. UDP listeners must be explicitly prefixed with udp/, e.g. udp/:5353.

Fix: add a formatListenAddress() helper that prepends udp/ when the host protocol is UDP. Also fix the grouping key used to merge hosts that share a listen address — it now includes the protocol, so a TCP and UDP host on the same port (e.g. DNS on :5353) correctly produce two separate Caddy layer4 servers instead of colliding.

[1] https://caddyserver.com/docs/conventions#network-addresses