### PR TITLE
fix(log-parser): detect geo-blocked requests in traffic stats

### DIFF
--- a/src/lib/log-parser.ts
+++ b/src/lib/log-parser.ts
@@ -79,6 +79,7 @@ interface CaddyLogEntry {
     proto?: string;
     headers?: Record<string, string[]>;
   };
+  resp_headers?: Record<string, string[]>;
 }
 
 // Build a set of signatures from caddy-blocker's "request blocked" entries so we
@@ -117,6 +118,15 @@ export function parseLine(line: string, blocked: Set<string>): typeof trafficEve
 
   const key = `${ts}|${clientIp}|${method}|${uri}`;
 
+  // Geo-blocker returns 403 via Caddy's own handler — these never produce a
+  // "request blocked" log entry, so they won't appear in the blocked set.
+  // Detect them by their response signature: status 403, Server header is
+  // "Caddy", and no Via header (which would indicate an upstream 403).
+  const isGeoBlocked =
+    status === 403 &&
+    entry.resp_headers?.['Server']?.[0] === 'Caddy' &&
+    !entry.resp_headers?.['Via'];
+
   return {
     ts,
     clientIp,
@@ -128,7 +138,7 @@ export function parseLine(line: string, blocked: Set<string>): typeof trafficEve
     proto: req.proto ?? '',
     bytesSent: entry.size ?? 0,
     userAgent: req.headers?.['User-Agent']?.[0] ?? '',
-    isBlocked: blocked.has(key),
+    isBlocked: blocked.has(key) || isGeoBlocked,
   };
 }
 

--- a/tests/unit/log-parser.test.ts
+++ b/tests/unit/log-parser.test.ts
@@ -177,5 +177,41 @@ describe('log-parser', () => {
       const result = parseLine(entry, emptyBlocked);
       expect(result!.countryCode).toBeNull();
     });
+
+    it('marks isBlocked true for geo-blocked requests (status 403, Server:Caddy, no Via)', () => {
+      const entry = JSON.stringify({
+        ts: 1700000500,
+        msg: 'handled request',
+        status: 403,
+        request: { client_ip: '1.2.3.4', host: 'example.com', method: 'GET', uri: '/' },
+        resp_headers: { Server: ['Caddy'] },
+      });
+      const result = parseLine(entry, emptyBlocked);
+      expect(result!.isBlocked).toBe(true);
+    });
+
+    it('does not mark isBlocked for upstream 403 responses (Via header present)', () => {
+      const entry = JSON.stringify({
+        ts: 1700000600,
+        msg: 'handled request',
+        status: 403,
+        request: { client_ip: '1.2.3.4', host: 'example.com', method: 'GET', uri: '/private' },
+        resp_headers: { Server: ['Caddy'], Via: ['1.1 upstream'] },
+      });
+      const result = parseLine(entry, emptyBlocked);
+      expect(result!.isBlocked).toBe(false);
+    });
+
+    it('does not mark isBlocked for non-403 Caddy responses', () => {
+      const entry = JSON.stringify({
+        ts: 1700000700,
+        msg: 'handled request',
+        status: 200,
+        request: { client_ip: '1.2.3.4', host: 'example.com', method: 'GET', uri: '/' },
+        resp_headers: { Server: ['Caddy'] },
+      });
+      const result = parseLine(entry, emptyBlocked);
+      expect(result!.isBlocked).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Problem

The blocked-attempts counter in CPM only counted WAF "request blocked" log entries. Requests rejected by the geo-blocker are handled entirely within Caddy — no `"request blocked"` log entry is emitted — so they were silently excluded from the traffic stats and the counter always showed 0.

Closes #84

## Root cause

`collectBlockedSignatures` scans for `msg === "request blocked"` + `plugin === "caddy-blocker"`. The geo-blocker short-circuits the request at the Caddy handler level and writes a normal `"handled request"` entry with `status: 403` and `resp_headers.Server: ["Caddy"]`.

## Fix

Detect geo-blocked requests by their response signature in `parseLine`:
- `status === 403`
- `resp_headers.Server === 'Caddy'` — set by Caddy itself, never by an upstream
- no `Via` header — which would indicate the 403 came from a proxied upstream

Add `resp_headers?: Record<string, string[]>` to the `CaddyLogEntry` interface and set `isBlocked` for any entry matching this signature, in addition to WAF-matched entries.

## Tests

Three new cases in `tests/unit/log-parser.test.ts`:
- geo-blocked 403 (Server:Caddy, no Via) → `isBlocked: true`
- upstream 403 with Via header → `isBlocked: false`
- non-403 Caddy response → `isBlocked: false`

## Verified

Tested against a live CPM instance: after applying the equivalent change to the compiled bundle, the blocked-attempts counter correctly reflected geo-blocked requests confirmed via an external proxy.