### PR TITLE
feat: restore ACME cert display via TLS probing (no filesystem access needed)

### DIFF
--- a/app/(dashboard)/certificates/CertificatesClient.tsx
+++ b/app/(dashboard)/certificates/CertificatesClient.tsx
@@ -44,6 +44,7 @@ export default function CertificatesClient({
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
 
   const allStatuses: (CertExpiryStatus | null)[] = [
+    ...acmeHosts.map((h) => h.certExpiryStatus),
     ...importedCerts.map((c) => c.expiryStatus),
   ];
   const { expired, expiringSoon, healthy } = countExpiry(allStatuses);

--- a/app/(dashboard)/certificates/components/AcmeTab.tsx
+++ b/app/(dashboard)/certificates/components/AcmeTab.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { DataTable } from "@/components/ui/DataTable";
 import { StatusChip } from "@/components/ui/StatusChip";
 import type { AcmeHost } from "../page";
+import { RelativeTime } from "./RelativeTime";
 
 type Props = {
   acmeHosts: AcmeHost[];
@@ -40,6 +41,18 @@ const columns = [
     ),
   },
   {
+    id: "issuer",
+    label: "Issuer",
+    render: (r: AcmeHost) => (
+      <span className="text-xs text-muted-foreground font-mono">{r.certIssuer ?? "—"}</span>
+    ),
+  },
+  {
+    id: "expiry",
+    label: "Expiry",
+    render: (r: AcmeHost) => <RelativeTime validTo={r.certValidTo} status={r.certExpiryStatus} />,
+  },
+  {
     id: "status",
     label: "Status",
     width: 110,
@@ -58,6 +71,7 @@ function acmeMobileCard(r: AcmeHost) {
           {r.domains[0]}{r.domains.length > 1 ? ` +${r.domains.length - 1}` : ""}
         </p>
         <div className="flex items-center gap-2 flex-wrap mt-1">
+          <RelativeTime validTo={r.certValidTo} status={r.certExpiryStatus} />
           <StatusChip status={r.enabled ? "active" : "inactive"} />
         </div>
       </CardContent>
@@ -67,7 +81,7 @@ function acmeMobileCard(r: AcmeHost) {
 
 export function AcmeTab({ acmeHosts, acmePagination, search, statusFilter }: Props) {
   const filtered = acmeHosts.filter((h) => {
-    if (statusFilter) return false; // ACME hosts have no expiry status
+    if (statusFilter && h.certExpiryStatus !== statusFilter) return false;
     if (search) {
       const q = search.toLowerCase();
       return (

--- a/app/(dashboard)/certificates/page.tsx
+++ b/app/(dashboard)/certificates/page.tsx
@@ -4,6 +4,7 @@ import { proxyHosts, certificates } from '@/src/lib/db/schema';
 import { isNull, isNotNull, count } from 'drizzle-orm';
 import { requireAdmin } from '@/src/lib/auth';
 import CertificatesClient from './CertificatesClient';
+import { scanAcmeCerts } from '@/src/lib/acme-certs';
 import { listCaCertificates, type CaCertificate } from '@/src/lib/models/ca-certificates';
 import { listIssuedClientCertificates, type IssuedClientCertificate } from '@/src/lib/models/issued-client-certificates';
 
@@ -22,6 +23,10 @@ export type AcmeHost = {
   domains: string[];
   ssl_forced: boolean;
   enabled: boolean;
+  certValidTo: string | null;
+  certValidFrom: string | null;
+  certIssuer: string | null;
+  certExpiryStatus: CertExpiryStatus | null;
 };
 
 export type ImportedCertView = {
@@ -117,13 +122,29 @@ export default async function CertificatesPage({ searchParams }: PageProps) {
       .where(isNotNull(proxyHosts.certificateId)),
   ]);
 
-  const acmeHosts: AcmeHost[] = acmeRows.map(r => ({
-    id: r.id,
-    name: r.name,
-    domains: JSON.parse(r.domains) as string[],
-    ssl_forced: r.sslForced,
-    enabled: r.enabled,
-  }));
+  // Collect all ACME domains for TLS probing
+  const allAcmeDomains = acmeRows.flatMap(r => JSON.parse(r.domains) as string[]);
+  const acmeCertMap = await scanAcmeCerts(allAcmeDomains);
+
+  const acmeHosts: AcmeHost[] = acmeRows.map(r => {
+    const domains = JSON.parse(r.domains) as string[];
+    let certInfo = null;
+    for (const domain of domains) {
+      const info = acmeCertMap.get(domain.toLowerCase());
+      if (info) { certInfo = info; break; }
+    }
+    return {
+      id: r.id,
+      name: r.name,
+      domains,
+      ssl_forced: r.sslForced,
+      enabled: r.enabled,
+      certValidTo: certInfo?.validTo ?? null,
+      certValidFrom: certInfo?.validFrom ?? null,
+      certIssuer: certInfo?.issuer ?? null,
+      certExpiryStatus: certInfo?.validTo ? getExpiryStatus(certInfo.validTo) : null,
+    };
+  });
 
   const usageMap = new Map<number, { id: number; name: string; domains: string[] }[]>();
   for (const u of usageRows) {

--- a/src/lib/acme-certs.ts
+++ b/src/lib/acme-certs.ts
@@ -1,0 +1,109 @@
+import * as tls from 'node:tls';
+
+export type AcmeCertInfo = {
+  validTo: string;
+  validFrom: string;
+  issuer: string;
+  domains: string[];
+};
+
+/**
+ * Connects to the Caddy server via TLS and reads the peer certificate
+ * presented for the given SNI hostname. This avoids reading Caddy's
+ * certificate storage directory (which uses 0700 permissions from
+ * certmagic, making it inaccessible to the web container).
+ */
+function probeCert(host: string, port: number, servername: string): Promise<AcmeCertInfo | null> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      resolve(null);
+    }, 5000);
+
+    const socket = tls.connect(
+      { host, port, servername, rejectUnauthorized: false },
+      () => {
+        clearTimeout(timeout);
+        const cert = socket.getPeerCertificate();
+        socket.end();
+
+        if (!cert || !cert.valid_to) {
+          resolve(null);
+          return;
+        }
+
+        // Extract SAN domains
+        const sanDomains =
+          (cert.subjectaltname ?? '')
+            .split(',')
+            .map((s: string) => s.trim())
+            .filter((s: string) => s.startsWith('DNS:'))
+            .map((s: string) => s.slice(4).toLowerCase());
+
+        // Extract issuer organization or CN
+        const issuer =
+          cert.issuer?.O ??
+          cert.issuer?.CN ??
+          (typeof cert.issuer === 'string' ? cert.issuer : '');
+
+        resolve({
+          validTo: new Date(cert.valid_to).toISOString(),
+          validFrom: new Date(cert.valid_from).toISOString(),
+          issuer: String(issuer).trim(),
+          domains: sanDomains,
+        });
+      },
+    );
+
+    socket.on('error', () => {
+      clearTimeout(timeout);
+      resolve(null);
+    });
+  });
+}
+
+/**
+ * Probes Caddy's TLS listener for each unique domain and returns a map
+ * from lowercase domain → cert info. The Caddy host and port are derived
+ * from CADDY_API_URL (defaults to caddy:443 for the TLS listener).
+ */
+export async function scanAcmeCerts(
+  domains: string[],
+): Promise<Map<string, AcmeCertInfo>> {
+  // Caddy's TLS listener — same host as the admin API, port 443
+  const apiUrl = process.env.CADDY_API_URL ?? 'http://caddy:2019';
+  const caddyHost = new URL(apiUrl).hostname;
+  const caddyPort = 443;
+
+  const unique = [...new Set(domains.map((d) => d.toLowerCase()))];
+  const map = new Map<string, AcmeCertInfo>();
+
+  // Probe in parallel with a concurrency limit
+  const CONCURRENCY = 5;
+  for (let i = 0; i < unique.length; i += CONCURRENCY) {
+    const batch = unique.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((domain) => probeCert(caddyHost, caddyPort, domain)),
+    );
+    for (let j = 0; j < batch.length; j++) {
+      const info = results[j];
+      if (!info) continue;
+      // A single cert may cover multiple domains (SAN); map all of them
+      for (const san of info.domains) {
+        const existing = map.get(san);
+        if (
+          !existing ||
+          new Date(info.validTo).getTime() > new Date(existing.validTo).getTime()
+        ) {
+          map.set(san, info);
+        }
+      }
+      // Also map the probed domain itself in case it's not in SAN list
+      if (!map.has(batch[j])) {
+        map.set(batch[j], info);
+      }
+    }
+  }
+
+  return map;
+}


### PR DESCRIPTION
## Context

Issue #88 identified that the Certificates page showed blank Issuer/Expiry fields because the web container couldn't read Caddy's certificate storage directory (`certmagic` creates it with hardcoded `0700` permissions). The fix in b9a88c4 removed the feature entirely, calling it "cosmetic."

The whole point of CPM is to simplify proxy and certificate management. Being able to glance at the Certificates page and instantly see issuer and expiry dates for all your domains is exactly the kind of thing that makes it useful — you shouldn't have to SSH in and run `openssl` commands just to check if your certs are healthy. Calling it "cosmetic" undersells its value; it's operational visibility with zero effort.

I'd love to see this feature stick around — it was one of the small things that made CPM feel complete.

## Approach

Rather than working around the `certmagic` `0700` permission issue or removing the feature, this PR takes a different approach entirely: it probes Caddy's TLS listener directly via `tls.connect()` with the appropriate SNI hostname. The web container already has network access to Caddy on the same Docker network — no volume mount, no filesystem permissions, no chmod hacks needed.

## How it works

1. `scanAcmeCerts()` receives the list of ACME-managed domains (already known from the DB)
2. For each unique domain, it opens a TLS connection to `caddy:443` with the domain as SNI
3. Reads the peer certificate from the handshake → `valid_from`, `valid_to`, `issuer`, SAN domains
4. Returns the same `Map<string, AcmeCertInfo>` the old implementation did

## What changed

- **New `src/lib/acme-certs.ts`** — TLS-probing implementation (replaces the deleted filesystem version)
- **`app/(dashboard)/certificates/page.tsx`** — Restores `certValidTo`, `certIssuer`, `certExpiryStatus` fields on `AcmeHost`; calls `scanAcmeCerts()` with domains from DB
- **`app/(dashboard)/certificates/CertificatesClient.tsx`** — ACME expiry status counted in summary bar again
- **`app/(dashboard)/certificates/components/AcmeTab.tsx`** — Issuer and Expiry columns restored; status filter re-enabled for ACME tab

## What's NOT needed anymore

- No `caddy-data` volume mount on the web container (`docker-compose.yml` change not reverted)
- No `CADDY_CERTS_DIR` env var
- No filesystem permissions workarounds

## Tested

Verified on a live CPM instance: patched the compiled chunk to use TLS probing, reverted `caddy-data` directory permissions back to `0700` (no group read), restarted the web container — Issuer (Let's Encrypt) and Expiry dates displayed correctly for all 6 managed domains.

Refs #88