### PR TITLE
Feature/proxy-hosts-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Data persists in Docker volumes (caddy-manager-data, caddy-data, caddy-config, c
 ## Features
 
 - **Proxy Hosts** - Reverse proxies with custom headers, multiple upstreams, load balancing (8 policies), active/passive health checks, retries, and enable/disable toggle
+- **Bulk Import** - Paste or upload a minimal Caddyfile or a Caddy runtime JSON config (`curl localhost:2019/config/`) to create proxy hosts in one operation. Auto-detects the format, previews detected hosts with conflict and skip flags, maps `transport.tls.insecure_skip_verify`, `static_response` redirects, and path-based location rules from JSON configs
 - **L4 Proxy Hosts** - TCP/UDP stream proxying with TLS SNI matching, proxy protocol (v1/v2), load balancing, health checks, and per-host geo blocking. Automatic Docker Compose port management via sidecar
 - **Location Rules** - Path-based routing to different upstreams per proxy host (e.g. `/api/*` to one backend, `/ws/*` to another)
 - **Redirect & Rewrite** - Per-host redirect rules (301/302/307/308) and path prefix rewriting

--- a/app/(dashboard)/proxy-hosts/ImportProxyHostsDialog.tsx
+++ b/app/(dashboard)/proxy-hosts/ImportProxyHostsDialog.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Check, FileUp, XCircle, AlertTriangle } from "lucide-react";
+import { parseCaddyfile, type CaddyfileImportResult } from "@/lib/caddyfile-import";
+import type { ProxyHost } from "@/lib/models/proxy-hosts";
+import {
+  importProxyHostsAction,
+  type ImportProxyHostsResult,
+} from "./actions";
+
+type Step = "input" | "preview" | "result";
+
+const MAX_BYTES = 1_000_000;
+const PLACEHOLDER = `example.com {
+    reverse_proxy 10.0.0.1:8080
+}
+
+other.example.com {
+    reverse_proxy 10.0.0.1:9090
+}`;
+
+export function ImportProxyHostsDialog({
+  open,
+  onClose,
+  existingHosts,
+}: {
+  open: boolean;
+  onClose: () => void;
+  existingHosts: ProxyHost[];
+}) {
+  const [step, setStep] = useState<Step>("input");
+  const [rawText, setRawText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ImportProxyHostsResult | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const parsed: CaddyfileImportResult = useMemo(
+    () => parseCaddyfile(rawText),
+    [rawText]
+  );
+
+  const existingDomains = useMemo(() => {
+    const set = new Set<string>();
+    for (const host of existingHosts) {
+      for (const d of host.domains) set.add(d.toLowerCase());
+    }
+    return set;
+  }, [existingHosts]);
+
+  const previewRows = useMemo(() => {
+    return parsed.drafts.map((draft) => {
+      const conflict = draft.domains.find((d) =>
+        existingDomains.has(d.toLowerCase())
+      );
+      return {
+        draft,
+        status: conflict ? ("skip" as const) : ("new" as const),
+        conflictDomain: conflict,
+      };
+    });
+  }, [parsed.drafts, existingDomains]);
+
+  const newCount = previewRows.filter((r) => r.status === "new").length;
+  const skipCount = previewRows.filter((r) => r.status === "skip").length;
+
+  function handleClose() {
+    setStep("input");
+    setRawText("");
+    setResult(null);
+    setErrorMessage(null);
+    setSubmitting(false);
+    onClose();
+  }
+
+  function handleFile(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (file.size > MAX_BYTES) {
+      setErrorMessage(`File too large (${file.size} > ${MAX_BYTES} bytes).`);
+      event.target.value = "";
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setRawText(String(reader.result ?? ""));
+      setErrorMessage(null);
+    };
+    reader.onerror = () => setErrorMessage("Failed to read file.");
+    reader.readAsText(file);
+    event.target.value = "";
+  }
+
+  async function handleImport() {
+    setSubmitting(true);
+    setErrorMessage(null);
+    const formData = new FormData();
+    formData.set("rawText", rawText);
+    const response = await importProxyHostsAction(undefined, formData);
+    setSubmitting(false);
+    if (response.status === "error") {
+      setErrorMessage(response.message ?? "Import failed.");
+      return;
+    }
+    setResult(response.result ?? { created: [], skipped: [], errors: [] });
+    setStep("result");
+  }
+
+  const canPreview =
+    rawText.trim().length > 0 &&
+    (parsed.drafts.length > 0 || parsed.errors.length > 0);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Import proxy hosts from Caddyfile</DialogTitle>
+          <DialogDescription>
+            Paste a minimal Caddyfile. Each <code>site &#123; reverse_proxy upstream &#125;</code> block becomes one proxy host. Other directives are not supported in v1. The preview detects domain conflicts against the current page; the server performs the final authoritative check.
+          </DialogDescription>
+        </DialogHeader>
+
+        {errorMessage && (
+          <Alert variant="destructive">
+            <AlertDescription>{errorMessage}</AlertDescription>
+          </Alert>
+        )}
+
+        {step === "input" && (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="caddyfile-input">Caddyfile content</Label>
+              <Textarea
+                id="caddyfile-input"
+                value={rawText}
+                onChange={(e) => setRawText(e.target.value)}
+                placeholder={PLACEHOLDER}
+                rows={14}
+                className="font-mono text-xs"
+              />
+              <p className="text-xs text-muted-foreground">
+                {parsed.drafts.length} host(s) detected · {parsed.errors.length} parse error(s)
+              </p>
+            </div>
+            <div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".caddyfile,.conf,.txt,text/plain"
+                className="hidden"
+                aria-label="Load Caddyfile from file"
+                onChange={handleFile}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <FileUp className="mr-2 h-4 w-4" />
+                Load from file
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === "preview" && (
+          <PreviewStep
+            rows={previewRows}
+            errors={parsed.errors}
+            newCount={newCount}
+            skipCount={skipCount}
+          />
+        )}
+
+        {step === "result" && result && (
+          <ResultStep result={result} />
+        )}
+
+        <DialogFooter>
+          {step === "input" && (
+            <>
+              <Button variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button
+                disabled={!canPreview}
+                onClick={() => setStep("preview")}
+              >
+                Preview
+              </Button>
+            </>
+          )}
+          {step === "preview" && (
+            <>
+              <Button variant="outline" onClick={() => setStep("input")}>
+                Back
+              </Button>
+              <Button
+                disabled={newCount === 0 || submitting}
+                onClick={handleImport}
+              >
+                {submitting ? (
+                  <>
+                    <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent mr-2" />
+                    Importing…
+                  </>
+                ) : (
+                  `Import ${newCount} host(s)`
+                )}
+              </Button>
+            </>
+          )}
+          {step === "result" && (
+            <Button onClick={handleClose}>Done</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PreviewStep({
+  rows,
+  errors,
+  newCount,
+  skipCount,
+}: {
+  rows: {
+    draft: { domains: string[]; upstream: string };
+    status: "new" | "skip";
+    conflictDomain?: string;
+  }[];
+  errors: CaddyfileImportResult["errors"];
+  newCount: number;
+  skipCount: number;
+}) {
+  return (
+    <div className="flex flex-col gap-4 max-h-[60vh] overflow-y-auto">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="success">{newCount} new</Badge>
+        <Badge variant="muted">{skipCount} skip</Badge>
+        <Badge variant="destructive">{errors.length} error</Badge>
+      </div>
+
+      {rows.length > 0 && (
+        <div className="rounded-md border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50">
+              <tr className="text-xs uppercase text-muted-foreground">
+                <th className="text-left font-medium px-3 py-2">Domains</th>
+                <th className="text-left font-medium px-3 py-2">Upstream</th>
+                <th className="text-left font-medium px-3 py-2 w-32">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, idx) => (
+                <tr key={idx} className="border-t">
+                  <td className="px-3 py-2 font-mono text-xs">
+                    {row.draft.domains.join(", ")}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs">
+                    {row.draft.upstream}
+                  </td>
+                  <td className="px-3 py-2">
+                    {row.status === "new" ? (
+                      <Badge variant="success">New</Badge>
+                    ) : (
+                      <Badge
+                        variant="muted"
+                        title={`Domain already in use: ${row.conflictDomain}`}
+                      >
+                        Skip — exists
+                      </Badge>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {errors.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <Label>Parse errors</Label>
+          {errors.map((err, idx) => (
+            <Alert key={idx} variant="destructive">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertDescription>
+                <div className="font-medium">
+                  Lines {err.lineStart}-{err.lineEnd}: {err.message}
+                </div>
+                <pre className="mt-2 overflow-x-auto rounded bg-destructive/10 p-2 font-mono text-[11px]">
+                  {err.raw}
+                </pre>
+              </AlertDescription>
+            </Alert>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ResultStep({ result }: { result: ImportProxyHostsResult }) {
+  return (
+    <div className="flex flex-col gap-4 max-h-[60vh] overflow-y-auto">
+      <ResultSection
+        label="Created"
+        count={result.created.length}
+        emptyText="No hosts created."
+      >
+        <ul className="flex flex-col gap-1">
+          {result.created.map((c) => (
+            <li
+              key={c.id}
+              className="flex items-center gap-2 text-sm font-mono"
+            >
+              <Check className="h-4 w-4 text-emerald-500 shrink-0" />
+              {c.primaryDomain}
+            </li>
+          ))}
+        </ul>
+      </ResultSection>
+
+      <ResultSection
+        label="Skipped"
+        count={result.skipped.length}
+        emptyText="Nothing skipped."
+      >
+        <ul className="flex flex-col gap-1">
+          {result.skipped.map((s, idx) => (
+            <li
+              key={idx}
+              className="flex items-start gap-2 text-sm"
+            >
+              <XCircle className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+              <span>
+                <span className="font-mono">{s.domains.join(", ")}</span>
+                <span className="text-muted-foreground">{` — ${s.reason}`}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </ResultSection>
+
+      <ResultSection
+        label="Parse errors"
+        count={result.errors.length}
+        emptyText="No parse errors."
+      >
+        <ul className="flex flex-col gap-1">
+          {result.errors.map((err, idx) => (
+            <li
+              key={idx}
+              className="flex items-start gap-2 text-sm"
+            >
+              <AlertTriangle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+              <span className="text-muted-foreground">
+                Lines {err.lineStart}-{err.lineEnd}: {err.message}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </ResultSection>
+    </div>
+  );
+}
+
+function ResultSection({
+  label,
+  count,
+  emptyText,
+  children,
+}: {
+  label: string;
+  count: number;
+  emptyText: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Label>{label}</Label>
+        <Badge variant="muted">{count}</Badge>
+      </div>
+      {count === 0 ? (
+        <p className="text-xs text-muted-foreground">{emptyText}</p>
+      ) : (
+        children
+      )}
+    </section>
+  );
+}

--- a/app/(dashboard)/proxy-hosts/ImportProxyHostsDialog.tsx
+++ b/app/(dashboard)/proxy-hosts/ImportProxyHostsDialog.tsx
@@ -14,8 +14,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Check, FileUp, XCircle, AlertTriangle } from "lucide-react";
-import { parseCaddyfile, type CaddyfileImportResult } from "@/lib/caddyfile-import";
+import { ArrowLeft, ArrowRight, Check, FileUp, X, XCircle, AlertTriangle } from "lucide-react";
+import { parseProxyHostsImport, type ImportResult, type ProxyHostImportDraft } from "@/lib/proxy-hosts-import";
 import type { ProxyHost } from "@/lib/models/proxy-hosts";
 import {
   importProxyHostsAction,
@@ -49,8 +49,8 @@ export function ImportProxyHostsDialog({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const parsed: CaddyfileImportResult = useMemo(
-    () => parseCaddyfile(rawText),
+  const parsed: ImportResult = useMemo(
+    () => parseProxyHostsImport(rawText),
     [rawText]
   );
 
@@ -116,21 +116,23 @@ export function ImportProxyHostsDialog({
       setErrorMessage(response.message ?? "Import failed.");
       return;
     }
-    setResult(response.result ?? { created: [], skipped: [], errors: [] });
+    setResult(response.result ?? { format: parsed.format, created: [], skipped: [], errors: [] });
     setStep("result");
   }
 
   const canPreview =
     rawText.trim().length > 0 &&
-    (parsed.drafts.length > 0 || parsed.errors.length > 0);
+    (parsed.drafts.length > 0 ||
+      parsed.errors.length > 0 ||
+      parsed.skipped.length > 0);
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
       <DialogContent className="max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Import proxy hosts from Caddyfile</DialogTitle>
+          <DialogTitle>Import proxy hosts</DialogTitle>
           <DialogDescription>
-            Paste a minimal Caddyfile. Each <code>site &#123; reverse_proxy upstream &#125;</code> block becomes one proxy host. Other directives are not supported in v1. The preview detects domain conflicts against the current page; the server performs the final authoritative check.
+            Paste a minimal Caddyfile or a Caddy runtime JSON config (e.g. from <code>curl localhost:2019/config/</code>). The format is auto-detected. The preview detects domain conflicts against the current page; the server performs the final authoritative check.
           </DialogDescription>
         </DialogHeader>
 
@@ -153,14 +155,15 @@ export function ImportProxyHostsDialog({
                 className="font-mono text-xs"
               />
               <p className="text-xs text-muted-foreground">
-                {parsed.drafts.length} host(s) detected · {parsed.errors.length} parse error(s)
+                Detected format: {parsed.format === "caddy-json" ? "Caddy JSON" : "Caddyfile"}.{" "}
+                {parsed.drafts.length} host(s) · {parsed.errors.length} error(s)
               </p>
             </div>
             <div>
               <input
                 ref={fileInputRef}
                 type="file"
-                accept=".caddyfile,.conf,.txt,text/plain"
+                accept=".caddyfile,.conf,.json,.txt,application/json,text/plain"
                 className="hidden"
                 aria-label="Load Caddyfile from file"
                 onChange={handleFile}
@@ -184,6 +187,8 @@ export function ImportProxyHostsDialog({
             errors={parsed.errors}
             newCount={newCount}
             skipCount={skipCount}
+            format={parsed.format}
+            parserSkipped={parsed.skipped}
           />
         )}
 
@@ -195,12 +200,14 @@ export function ImportProxyHostsDialog({
           {step === "input" && (
             <>
               <Button variant="outline" onClick={handleClose}>
+                <X className="mr-2 h-4 w-4" />
                 Cancel
               </Button>
               <Button
                 disabled={!canPreview}
                 onClick={() => setStep("preview")}
               >
+                <ArrowRight className="mr-2 h-4 w-4" />
                 Preview
               </Button>
             </>
@@ -208,6 +215,7 @@ export function ImportProxyHostsDialog({
           {step === "preview" && (
             <>
               <Button variant="outline" onClick={() => setStep("input")}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
                 Back
               </Button>
               <Button
@@ -220,13 +228,19 @@ export function ImportProxyHostsDialog({
                     Importing…
                   </>
                 ) : (
-                  `Import ${newCount} host(s)`
+                  <>
+                    <FileUp className="mr-2 h-4 w-4" />
+                    {`Import ${newCount} host(s)`}
+                  </>
                 )}
               </Button>
             </>
           )}
           {step === "result" && (
-            <Button onClick={handleClose}>Done</Button>
+            <Button onClick={handleClose}>
+              <Check className="mr-2 h-4 w-4" />
+              Done
+            </Button>
           )}
         </DialogFooter>
       </DialogContent>
@@ -239,31 +253,37 @@ function PreviewStep({
   errors,
   newCount,
   skipCount,
+  format,
+  parserSkipped,
 }: {
   rows: {
-    draft: { domains: string[]; upstream: string };
+    draft: ProxyHostImportDraft;
     status: "new" | "skip";
     conflictDomain?: string;
   }[];
-  errors: CaddyfileImportResult["errors"];
+  errors: ImportResult["errors"];
   newCount: number;
   skipCount: number;
+  format: ImportResult["format"];
+  parserSkipped: ImportResult["skipped"];
 }) {
   return (
     <div className="flex flex-col gap-4 max-h-[60vh] overflow-y-auto">
       <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="muted">Format: {format === "caddy-json" ? "Caddy JSON" : "Caddyfile"}</Badge>
         <Badge variant="success">{newCount} new</Badge>
-        <Badge variant="muted">{skipCount} skip</Badge>
+        <Badge variant="muted">{skipCount + parserSkipped.length} skip</Badge>
         <Badge variant="destructive">{errors.length} error</Badge>
       </div>
 
       {rows.length > 0 && (
-        <div className="rounded-md border overflow-hidden">
+        <div className="rounded-md border max-h-[40vh] overflow-y-auto">
           <table className="w-full text-sm">
-            <thead className="bg-muted/50">
+            <thead className="sticky top-0 z-10 bg-muted">
               <tr className="text-xs uppercase text-muted-foreground">
                 <th className="text-left font-medium px-3 py-2">Domains</th>
                 <th className="text-left font-medium px-3 py-2">Upstream</th>
+                <th className="text-left font-medium px-3 py-2">Features</th>
                 <th className="text-left font-medium px-3 py-2 w-32">Status</th>
               </tr>
             </thead>
@@ -271,10 +291,18 @@ function PreviewStep({
               {rows.map((row, idx) => (
                 <tr key={idx} className="border-t">
                   <td className="px-3 py-2 font-mono text-xs">
-                    {row.draft.domains.join(", ")}
+                    <div className="flex items-center gap-1">
+                      <span>{row.draft.domains.join(", ")}</span>
+                      {row.draft.warnings && row.draft.warnings.length > 0 && (
+                        <span title={row.draft.warnings.join("\n")}>
+                          <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+                        </span>
+                      )}
+                    </div>
                   </td>
-                  <td className="px-3 py-2 font-mono text-xs">
-                    {row.draft.upstream}
+                  <td className="px-3 py-2 font-mono text-xs">{row.draft.upstream}</td>
+                  <td className="px-3 py-2">
+                    <FeatureBadges draft={row.draft} />
                   </td>
                   <td className="px-3 py-2">
                     {row.status === "new" ? (
@@ -303,7 +331,7 @@ function PreviewStep({
               <AlertTriangle className="h-4 w-4" />
               <AlertDescription>
                 <div className="font-medium">
-                  Lines {err.lineStart}-{err.lineEnd}: {err.message}
+                  {err.locator}: {err.message}
                 </div>
                 <pre className="mt-2 overflow-x-auto rounded bg-destructive/10 p-2 font-mono text-[11px]">
                   {err.raw}
@@ -313,8 +341,52 @@ function PreviewStep({
           ))}
         </div>
       )}
+
+      {parserSkipped.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <Label>Skipped by parser</Label>
+          <ul className="flex flex-col gap-1">
+            {parserSkipped.map((s) => (
+              <li key={s.draft.domains.join(",")} className="flex items-start gap-2 text-sm">
+                <XCircle className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+                <span>
+                  <span className="font-mono">{s.draft.domains.join(", ")}</span>
+                  <span className="text-muted-foreground">{` — ${s.reason}`}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
+}
+
+function FeatureBadges({ draft }: { draft: ProxyHostImportDraft }) {
+  const badges: React.ReactNode[] = [];
+  if (draft.skipHttpsHostnameValidation) {
+    badges.push(
+      <Badge key="tls" variant="muted" className="text-[10px]">
+        TLS skip
+      </Badge>
+    );
+  }
+  if (draft.redirects && draft.redirects.length > 0) {
+    badges.push(
+      <Badge key="redir" variant="muted" className="text-[10px]">
+        {draft.redirects.length} redirect{draft.redirects.length === 1 ? "" : "s"}
+      </Badge>
+    );
+  }
+  if (draft.locationRules && draft.locationRules.length > 0) {
+    badges.push(
+      <Badge key="loc" variant="muted" className="text-[10px]">
+        {draft.locationRules.length} location rule{draft.locationRules.length === 1 ? "" : "s"}
+      </Badge>
+    );
+  }
+  if (badges.length === 0) return <span className="text-xs text-muted-foreground">—</span>;
+  return <div className="flex flex-wrap gap-1">{badges}</div>;
 }
 
 function ResultStep({ result }: { result: ImportProxyHostsResult }) {
@@ -372,7 +444,7 @@ function ResultStep({ result }: { result: ImportProxyHostsResult }) {
             >
               <AlertTriangle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
               <span className="text-muted-foreground">
-                Lines {err.lineStart}-{err.lineEnd}: {err.message}
+                {err.locator}: {err.message}
               </span>
             </li>
           ))}

--- a/app/(dashboard)/proxy-hosts/ProxyHostsClient.tsx
+++ b/app/(dashboard)/proxy-hosts/ProxyHostsClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import { Globe, MoreHorizontal, ArrowRight, Shield, Bug, MapPin, Scale, KeyRound, UserCheck, CornerRightDown, Replace } from "lucide-react";
+import { Globe, MoreHorizontal, ArrowRight, Shield, Bug, MapPin, Scale, KeyRound, UserCheck, CornerRightDown, Replace, FileUp } from "lucide-react";
 import type { AccessList } from "@/lib/models/access-lists";
 import type { Certificate } from "@/lib/models/certificates";
 import type { ProxyHost } from "@/lib/models/proxy-hosts";
@@ -16,6 +16,7 @@ import { SearchField } from "@/components/ui/SearchField";
 import { DataTable } from "@/components/ui/DataTable";
 import { StatusChip } from "@/components/ui/StatusChip";
 import { CreateHostDialog, EditHostDialog, DeleteHostDialog } from "@/components/proxy-hosts/HostDialogs";
+import { ImportProxyHostsDialog } from "./ImportProxyHostsDialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
@@ -50,6 +51,7 @@ type Props = {
 
 export default function ProxyHostsClient({ hosts, certificates, accessLists, caCertificates, authentikDefaults, pagination, initialSearch, initialSort, mtlsRoles, issuedClientCerts, forwardAuthUsers, forwardAuthGroups, forwardAuthAccessMap }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [duplicateHost, setDuplicateHost] = useState<ProxyHost | null>(null);
   const [editHost, setEditHost] = useState<ProxyHost | null>(null);
   const [deleteHost, setDeleteHost] = useState<ProxyHost | null>(null);
@@ -286,6 +288,10 @@ export default function ProxyHostsClient({ hosts, certificates, accessLists, caC
           onChange={(e) => handleSearchChange(e.target.value)}
           placeholder="Search hosts..."
         />
+        <Button variant="outline" onClick={() => setImportOpen(true)}>
+          <FileUp className="h-4 w-4 mr-2" />
+          Import
+        </Button>
       </div>
 
       <DataTable
@@ -312,6 +318,12 @@ export default function ProxyHostsClient({ hosts, certificates, accessLists, caC
         issuedClientCerts={issuedClientCerts ?? []}
         forwardAuthUsers={forwardAuthUsers ?? []}
         forwardAuthGroups={forwardAuthGroups ?? []}
+      />
+
+      <ImportProxyHostsDialog
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        existingHosts={hosts}
       />
 
       {editHost && (

--- a/app/(dashboard)/proxy-hosts/actions.ts
+++ b/app/(dashboard)/proxy-hosts/actions.ts
@@ -6,6 +6,7 @@ import { actionError, actionSuccess, INITIAL_ACTION_STATE, type ActionState } fr
 import {
   createProxyHost,
   deleteProxyHost,
+  listProxyHosts,
   updateProxyHost,
   type ProxyHostAuthentikInput,
   type LoadBalancerInput,
@@ -19,6 +20,10 @@ import {
   type RewriteConfig,
   type CpmForwardAuthInput
 } from "@/src/lib/models/proxy-hosts";
+import {
+  parseCaddyfile,
+  type CaddyfileImportError,
+} from "@/src/lib/caddyfile-import";
 import { getCertificate } from "@/src/lib/models/certificates";
 import { setForwardAuthAccess } from "@/src/lib/models/forward-auth";
 import { getCloudflareSettings, type GeoBlockSettings } from "@/src/lib/settings";
@@ -691,5 +696,115 @@ export async function toggleProxyHostAction(
   } catch (error) {
     console.error(`Failed to toggle proxy host ${id}:`, error);
     return actionError(error, "Failed to toggle proxy host. Please check the logs for details.");
+  }
+}
+
+const MAX_IMPORT_BYTES = 1_000_000; // 1 MB
+
+export type ImportProxyHostsResult = {
+  created: { id: number; primaryDomain: string }[];
+  skipped: { domains: string[]; reason: string }[];
+  errors: CaddyfileImportError[];
+};
+
+export type ImportProxyHostsActionState = ActionState & {
+  result?: ImportProxyHostsResult;
+};
+
+export async function importProxyHostsAction(
+  _prevState: ImportProxyHostsActionState = INITIAL_ACTION_STATE,
+  formData: FormData
+): Promise<ImportProxyHostsActionState> {
+  void _prevState;
+  try {
+    const session = await requireAdmin();
+    const userId = Number(session.user.id);
+
+    const rawText = String(formData.get("rawText") ?? "");
+    if (rawText.length === 0) {
+      return { ...actionError(new Error("No input provided"), "No input provided") };
+    }
+    if (rawText.length > MAX_IMPORT_BYTES) {
+      return {
+        ...actionError(
+          new Error(`Input too large (${rawText.length} > ${MAX_IMPORT_BYTES} bytes)`),
+          "Input too large"
+        ),
+      };
+    }
+
+    const parsed = parseCaddyfile(rawText);
+
+    // Note: this snapshot is not atomic with createProxyHost. Concurrent imports
+    // or manual creates in another session can still create duplicate domains —
+    // the proxy_hosts table has no UNIQUE constraint on the JSON-encoded domains
+    // column. This is an inherent model-layer limitation, not specific to import.
+    // Build the set of domains already in use.
+    const existingHosts = await listProxyHosts();
+    const usedDomains = new Set<string>();
+    for (const host of existingHosts) {
+      for (const domain of host.domains) {
+        usedDomains.add(domain.toLowerCase());
+      }
+    }
+
+    const created: ImportProxyHostsResult["created"] = [];
+    const skipped: ImportProxyHostsResult["skipped"] = [];
+
+    for (const draft of parsed.drafts) {
+      const conflict = draft.domains.find((d) => usedDomains.has(d.toLowerCase()));
+      if (conflict) {
+        skipped.push({
+          domains: draft.domains,
+          reason: `Domain already in use: ${conflict}`,
+        });
+        continue;
+      }
+
+      try {
+        const host = await createProxyHost(
+          {
+            name: draft.domains[0],
+            domains: draft.domains,
+            upstreams: [draft.upstream],
+            enabled: true,
+            hstsSubdomains: true,
+          },
+          userId
+        );
+        created.push({ id: host.id, primaryDomain: host.domains[0] });
+        // Reserve these domains for the rest of this import run.
+        for (const d of draft.domains) {
+          usedDomains.add(d.toLowerCase());
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "create failed";
+        skipped.push({
+          domains: draft.domains,
+          reason: `Create failed: ${message}`,
+        });
+        // Reserve anyway to prevent sibling drafts from attempting the same domains.
+        for (const d of draft.domains) {
+          usedDomains.add(d.toLowerCase());
+        }
+      }
+    }
+
+    if (created.length > 0) {
+      revalidatePath("/proxy-hosts");
+    }
+
+    const summary = `Imported ${created.length} proxy host(s). Skipped ${skipped.length}. Parse errors: ${parsed.errors.length}.`;
+    return {
+      ...actionSuccess(summary),
+      result: {
+        created,
+        skipped,
+        errors: parsed.errors,
+      },
+    };
+  } catch (error) {
+    console.error("Failed to import proxy hosts:", error);
+    return actionError(error, "Failed to import proxy hosts. Please check the logs for details.");
   }
 }

--- a/app/(dashboard)/proxy-hosts/actions.ts
+++ b/app/(dashboard)/proxy-hosts/actions.ts
@@ -21,9 +21,10 @@ import {
   type CpmForwardAuthInput
 } from "@/src/lib/models/proxy-hosts";
 import {
-  parseCaddyfile,
-  type CaddyfileImportError,
-} from "@/src/lib/caddyfile-import";
+  parseProxyHostsImport,
+  type ImportError as ProxyHostImportError,
+  type ImportFormat,
+} from "@/src/lib/proxy-hosts-import";
 import { getCertificate } from "@/src/lib/models/certificates";
 import { setForwardAuthAccess } from "@/src/lib/models/forward-auth";
 import { getCloudflareSettings, type GeoBlockSettings } from "@/src/lib/settings";
@@ -702,9 +703,10 @@ export async function toggleProxyHostAction(
 const MAX_IMPORT_BYTES = 1_000_000; // 1 MB
 
 export type ImportProxyHostsResult = {
+  format: ImportFormat;
   created: { id: number; primaryDomain: string }[];
   skipped: { domains: string[]; reason: string }[];
-  errors: CaddyfileImportError[];
+  errors: ProxyHostImportError[];
 };
 
 export type ImportProxyHostsActionState = ActionState & {
@@ -733,7 +735,7 @@ export async function importProxyHostsAction(
       };
     }
 
-    const parsed = parseCaddyfile(rawText);
+    const parsed = parseProxyHostsImport(rawText);
 
     // Note: this snapshot is not atomic with createProxyHost. Concurrent imports
     // or manual creates in another session can still create duplicate domains —
@@ -762,13 +764,22 @@ export async function importProxyHostsAction(
       }
 
       try {
+        const primaryDomain = draft.domains[0];
+        // Use the leftmost label as the display name when the domain has a subdomain;
+        // fall back to the full domain for single-label hosts (e.g. "localhost").
+        const dotIdx = primaryDomain.indexOf(".");
+        const label = dotIdx > 0 ? primaryDomain.slice(0, dotIdx) : primaryDomain;
+        const hostName = label.length > 0 ? label[0].toUpperCase() + label.slice(1) : label;
         const host = await createProxyHost(
           {
-            name: draft.domains[0],
+            name: hostName,
             domains: draft.domains,
             upstreams: [draft.upstream],
             enabled: true,
             hstsSubdomains: true,
+            skipHttpsHostnameValidation: draft.skipHttpsHostnameValidation,
+            redirects: draft.redirects,
+            locationRules: draft.locationRules,
           },
           userId
         );
@@ -790,6 +801,10 @@ export async function importProxyHostsAction(
       }
     }
 
+    for (const s of parsed.skipped) {
+      skipped.push({ domains: s.draft.domains, reason: s.reason });
+    }
+
     if (created.length > 0) {
       revalidatePath("/proxy-hosts");
     }
@@ -798,6 +813,7 @@ export async function importProxyHostsAction(
     return {
       ...actionSuccess(summary),
       result: {
+        format: parsed.format,
         created,
         skipped,
         errors: parsed.errors,

--- a/src/lib/caddy-json-import.ts
+++ b/src/lib/caddy-json-import.ts
@@ -1,0 +1,285 @@
+/**
+ * Pure parser for Caddy's runtime JSON config (the format returned by
+ * `curl localhost:2019/config/`). Drilled into proxy-host drafts for CPM.
+ *
+ * The parser is pure and never throws on input; malformed inputs produce
+ * `errors` entries.
+ */
+
+import type {
+  ImportResult,
+  ProxyHostImportDraft,
+  ImportError,
+  ImportSkipped,
+} from "./proxy-hosts-import";
+
+function emptyResult(): ImportResult {
+  return {
+    drafts: [],
+    errors: [],
+    skipped: [],
+    format: "caddy-json",
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseCaddyJson(raw: string): ImportResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "parse failed";
+    return {
+      ...emptyResult(),
+      errors: [{ locator: "(root)", message: `Invalid JSON: ${message}` }],
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return {
+      ...emptyResult(),
+      errors: [{ locator: "(root)", message: "Root must be a JSON object" }],
+    };
+  }
+
+  const apps = (parsed as Record<string, unknown>).apps;
+  const http = isRecord(apps) ? apps.http : undefined;
+  const servers = isRecord(http) ? (http as Record<string, unknown>).servers : undefined;
+
+  if (!isRecord(servers)) {
+    return {
+      ...emptyResult(),
+      errors: [
+        {
+          locator: "(root)",
+          message: "Not a Caddy HTTP config: missing or invalid apps.http.servers",
+        },
+      ],
+    };
+  }
+
+  const errors: ImportError[] = [];
+  const skipped: ImportSkipped[] = [];
+
+  // domain (lowercased) -> { port, draft } currently winning
+  const winners = new Map<string, { port: number | null; draft: ProxyHostImportDraft }>();
+  // Preserve insertion order for the final output.
+  const winnerOrder: string[] = [];
+
+  for (const [serverName, serverValue] of Object.entries(servers)) {
+    if (!isRecord(serverValue)) continue;
+    const routes = (serverValue as Record<string, unknown>).routes;
+    if (!Array.isArray(routes)) continue;
+    const listenArr = (serverValue as Record<string, unknown>).listen;
+    const port = parsePort(Array.isArray(listenArr) ? listenArr[0] : undefined);
+
+    routes.forEach((route, routeIndex) => {
+      const locator = `${serverName}.routes[${routeIndex}]`;
+      const extracted = extractDraftFromRoute(route, locator);
+      if (extracted.kind === "error") {
+        errors.push(extracted.error);
+        return;
+      }
+      if (extracted.kind === "skip") {
+        if (extracted.draft) skipped.push({ draft: extracted.draft, reason: extracted.reason });
+        return;
+      }
+      // kind === "draft"
+      const newDraft = extracted.draft;
+      const key = newDraft.domains[0].toLowerCase();
+      const existing = winners.get(key);
+      if (!existing) {
+        winners.set(key, { port, draft: newDraft });
+        winnerOrder.push(key);
+      } else if (existing.port !== 443 && port === 443) {
+        skipped.push({
+          draft: existing.draft,
+          reason: `superseded by :${port} server`,
+        });
+        winners.set(key, { port, draft: newDraft });
+      } else {
+        const loserPort = existing.port ?? "?";
+        skipped.push({
+          draft: newDraft,
+          reason: `superseded by :${loserPort} server`,
+        });
+      }
+    });
+  }
+
+  const drafts: ProxyHostImportDraft[] = [];
+  for (const key of winnerOrder) {
+    const entry = winners.get(key);
+    if (entry) drafts.push(entry.draft);
+  }
+
+  return { drafts, errors, skipped, format: "caddy-json" };
+}
+
+type RouteExtraction =
+  | { kind: "draft"; draft: ProxyHostImportDraft }
+  | { kind: "error"; error: ImportError }
+  | { kind: "skip"; reason: string; draft?: ProxyHostImportDraft };
+
+function extractDraftFromRoute(route: unknown, locator: string): RouteExtraction {
+  if (!isRecord(route)) {
+    return { kind: "error", error: { locator, message: "route is not an object" } };
+  }
+
+  const domains = extractDomains(route);
+  if (domains.length === 0) {
+    return { kind: "error", error: { locator, message: "route has no host matcher" } };
+  }
+
+  const handlers = collectHandlers(route);
+
+  const warnings: string[] = [];
+  for (const h of handlers) {
+    if (h.handlerName === "headers") {
+      warnings.push("Custom headers ignored; configure HSTS or preserveHostHeader in CPM.");
+    } else if (h.handlerName === "authentication") {
+      warnings.push("Authentication handler ignored; configure CPM Forward Auth or Authentik manually.");
+    }
+  }
+  // Deduplicate warnings to keep the UI tidy.
+  const uniqueWarnings = Array.from(new Set(warnings));
+
+  const reverseProxies = handlers.filter((h) => h.handlerName === "reverse_proxy");
+  if (reverseProxies.length === 0) {
+    const placeholder: ProxyHostImportDraft = {
+      domains,
+      upstream: "",
+      source: { format: "caddy-json", locator },
+    };
+    return { kind: "skip", reason: "no reverse_proxy handler", draft: placeholder };
+  }
+
+  // Primary: the first reverse_proxy without a path matcher. Fallback: the
+  // very first reverse_proxy, in source order.
+  const primary = reverseProxies.find((h) => !h.matchPath) ?? reverseProxies[0];
+  const primaryUpstream = extractUpstream(primary.handler);
+  if (!primaryUpstream) {
+    return { kind: "error", error: { locator, message: "reverse_proxy has no usable upstream" } };
+  }
+
+  const locationRules: { path: string; upstreams: string[] }[] = [];
+  for (const h of reverseProxies) {
+    if (h === primary) continue;
+    if (!h.matchPath) continue;
+    const u = extractUpstream(h.handler);
+    if (!u) continue;
+    locationRules.push({ path: h.matchPath, upstreams: [u] });
+  }
+
+  const redirects: { from: string; to: string; status: 301 | 302 | 307 | 308 }[] = [];
+  for (const h of handlers) {
+    if (h.handlerName !== "static_response") continue;
+    const status = h.handler.status_code;
+    const headers = h.handler.headers;
+    if (status !== 301 && status !== 302 && status !== 307 && status !== 308) continue;
+    if (!isRecord(headers)) continue;
+    const locationArr = (headers as Record<string, unknown>).Location;
+    if (!Array.isArray(locationArr) || typeof locationArr[0] !== "string") continue;
+    const from = h.matchPath;
+    if (!from) continue;
+    redirects.push({ from, to: locationArr[0], status });
+  }
+
+  const transport = primary.handler.transport;
+  const tlsConfig = isRecord(transport) ? transport.tls : undefined;
+  const hasTls = isRecord(tlsConfig);
+  const skipVerify = hasTls && tlsConfig.insecure_skip_verify === true;
+
+  const normalizedUpstream =
+    hasTls && !/^https?:\/\//.test(primaryUpstream) ? `https://${primaryUpstream}` : primaryUpstream;
+
+  const draft: ProxyHostImportDraft = {
+    domains,
+    upstream: normalizedUpstream,
+    source: { format: "caddy-json", locator },
+  };
+  if (skipVerify) draft.skipHttpsHostnameValidation = true;
+  if (redirects.length > 0) draft.redirects = redirects;
+  if (locationRules.length > 0) draft.locationRules = locationRules;
+  if (uniqueWarnings.length > 0) draft.warnings = uniqueWarnings;
+  return { kind: "draft", draft };
+}
+
+function extractDomains(route: Record<string, unknown>): string[] {
+  const match = route.match;
+  if (!Array.isArray(match) || match.length === 0) return [];
+  const first = match[0];
+  if (!isRecord(first)) return [];
+  const hosts = (first as Record<string, unknown>).host;
+  if (!Array.isArray(hosts)) return [];
+  return hosts.filter((h): h is string => typeof h === "string" && h.length > 0);
+}
+
+interface FlatHandler {
+  handlerName: string;
+  handler: Record<string, unknown>;
+  /** Path matcher inherited from the surrounding inner route, if any. */
+  matchPath?: string;
+}
+
+function collectHandlers(route: Record<string, unknown>): FlatHandler[] {
+  const out: FlatHandler[] = [];
+  walkHandle(route.handle, undefined, out);
+  return out;
+}
+
+function walkHandle(
+  handleValue: unknown,
+  inheritedPath: string | undefined,
+  out: FlatHandler[]
+): void {
+  if (!Array.isArray(handleValue)) return;
+  for (const entry of handleValue) {
+    if (!isRecord(entry)) continue;
+    const handlerName = typeof entry.handler === "string" ? entry.handler : "";
+    if (handlerName === "subroute") {
+      const inner = (entry as Record<string, unknown>).routes;
+      if (Array.isArray(inner)) {
+        for (const innerRoute of inner) {
+          if (!isRecord(innerRoute)) continue;
+          const innerPath = extractFirstPath(innerRoute) ?? inheritedPath;
+          walkHandle(innerRoute.handle, innerPath, out);
+        }
+      }
+    } else if (handlerName) {
+      out.push({ handlerName, handler: entry as Record<string, unknown>, matchPath: inheritedPath });
+    }
+  }
+}
+
+function extractFirstPath(innerRoute: Record<string, unknown>): string | undefined {
+  const match = innerRoute.match;
+  if (!Array.isArray(match)) return undefined;
+  for (const m of match) {
+    if (!isRecord(m)) continue;
+    const path = (m as Record<string, unknown>).path;
+    if (Array.isArray(path) && typeof path[0] === "string") return path[0];
+  }
+  return undefined;
+}
+
+function extractUpstream(handler: Record<string, unknown>): string | undefined {
+  const upstreams = handler.upstreams;
+  if (!Array.isArray(upstreams) || upstreams.length === 0) return undefined;
+  const first = upstreams[0];
+  if (!isRecord(first)) return undefined;
+  const dial = (first as Record<string, unknown>).dial;
+  return typeof dial === "string" && dial.length > 0 ? dial : undefined;
+}
+
+function parsePort(listen: unknown): number | null {
+  if (typeof listen !== "string") return null;
+  // Caddy listen entries look like ":443" or "0.0.0.0:443".
+  const match = /:(\d+)$/.exec(listen);
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/lib/caddyfile-import.ts
+++ b/src/lib/caddyfile-import.ts
@@ -1,0 +1,215 @@
+/**
+ * Pure parser for the minimal Caddyfile subset that CPM accepts as import input.
+ *
+ * Supported grammar (v1):
+ *   File       := (Comment | Blank | SiteBlock)*
+ *   SiteBlock  := DomainList "{" (Comment | Blank | ReverseProxy)* "}"
+ *   DomainList := Domain ("," Domain)*
+ *   ReverseProxy := "reverse_proxy" Upstream
+ *
+ * Any other directive inside a site block makes the whole block an error.
+ * The parser never throws on input; malformed sections are returned as `errors`.
+ */
+
+export interface CaddyfileImportDraft {
+  domains: string[];
+  upstream: string;
+  /** 1-based inclusive line number where the site block starts. */
+  lineStart: number;
+  /** 1-based inclusive line number where the site block ends. */
+  lineEnd: number;
+}
+
+export interface CaddyfileImportError {
+  lineStart: number;
+  lineEnd: number;
+  message: string;
+  /** The offending block (or partial line) verbatim, for display in the UI. */
+  raw: string;
+}
+
+export interface CaddyfileImportResult {
+  drafts: CaddyfileImportDraft[];
+  errors: CaddyfileImportError[];
+}
+
+type Line = { num: number; text: string; trimmed: string };
+
+function tokenizeLines(raw: string): Line[] {
+  const lines = raw.split(/\r?\n/);
+  return lines.map((text, i) => ({ num: i + 1, text, trimmed: text.trim() }));
+}
+
+function isCommentOrBlank(trimmed: string): boolean {
+  return trimmed.length === 0 || trimmed.startsWith('#');
+}
+
+function splitDomains(headerWithoutBrace: string): string[] {
+  return headerWithoutBrace
+    .split(',')
+    .map((d) => d.trim())
+    .filter((d) => d.length > 0);
+}
+
+function joinRaw(lines: Line[], start: number, end: number): string {
+  return lines
+    .slice(start - 1, end)
+    .map((l) => l.text)
+    .join('\n');
+}
+
+export function parseCaddyfile(raw: string): CaddyfileImportResult {
+  const drafts: CaddyfileImportDraft[] = [];
+  const errors: CaddyfileImportError[] = [];
+  const cleaned = raw.startsWith('﻿') ? raw.slice(1) : raw;
+  const lines = tokenizeLines(cleaned);
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (isCommentOrBlank(line.trimmed)) {
+      i++;
+      continue;
+    }
+
+    // Site block header: either "<domains> {" or "<domains>" then next non-blank is "{".
+    let headerText = line.trimmed;
+    const lineStart = line.num;
+    let cursor: number;
+
+    if (headerText.endsWith('{')) {
+      headerText = headerText.slice(0, -1).trim();
+      cursor = i + 1;
+    } else {
+      // Look ahead for "{" on its own line, skipping blank/comment lines.
+      let j = i + 1;
+      while (j < lines.length && isCommentOrBlank(lines[j].trimmed)) j++;
+      if (j < lines.length && lines[j].trimmed === '{') {
+        cursor = j + 1;
+      } else {
+        const message = line.trimmed.includes('{')
+          ? 'Single-line blocks are not supported; the closing "}" must be on its own line'
+          : 'Expected "{" after domain list';
+        errors.push({
+          lineStart,
+          lineEnd: line.num,
+          message,
+          raw: line.text,
+        });
+        i = i + 1;
+        continue;
+      }
+    }
+
+    const domains = splitDomains(headerText);
+    if (domains.length === 0) {
+      errors.push({
+        lineStart,
+        lineEnd: line.num,
+        message: 'Empty domain list before "{"',
+        raw: line.text,
+      });
+      // Skip to matching "}" or EOF.
+      while (cursor < lines.length && lines[cursor].trimmed !== '}') cursor++;
+      i = cursor + 1;
+      continue;
+    }
+
+    // Body: collect directives until "}".
+    const reverseProxyValues: string[] = [];
+    const unsupported: { name: string; line: number }[] = [];
+    let closed = false;
+    let bodyEnd = cursor - 1;
+
+    while (cursor < lines.length) {
+      const bodyLine = lines[cursor];
+      if (isCommentOrBlank(bodyLine.trimmed)) {
+        cursor++;
+        continue;
+      }
+      if (bodyLine.trimmed === '}') {
+        closed = true;
+        bodyEnd = bodyLine.num;
+        cursor++;
+        break;
+      }
+      // Tokenize: first word is the directive name.
+      const tokens = bodyLine.trimmed.split(/\s+/);
+      const name = tokens[0];
+      if (name === 'reverse_proxy') {
+        if (tokens.length > 2) {
+          unsupported.push({ name: 'reverse_proxy (multi-upstream)', line: bodyLine.num });
+        } else {
+          reverseProxyValues.push(tokens[1] ?? '');
+        }
+      } else {
+        unsupported.push({ name, line: bodyLine.num });
+      }
+      cursor++;
+    }
+
+    if (!closed) {
+      errors.push({
+        lineStart,
+        lineEnd: lines.length,
+        message: 'Site block is missing closing "}"',
+        raw: joinRaw(lines, lineStart, lines.length),
+      });
+      i = lines.length;
+      continue;
+    }
+
+    const lineEnd = bodyEnd;
+
+    if (unsupported.length > 0) {
+      const names = Array.from(new Set(unsupported.map((u) => u.name))).join(', ');
+      errors.push({
+        lineStart,
+        lineEnd,
+        message: `Unsupported directive(s) in site block: ${names}. Only "reverse_proxy" is supported.`,
+        raw: joinRaw(lines, lineStart, lineEnd),
+      });
+      i = cursor;
+      continue;
+    }
+
+    if (reverseProxyValues.length === 0) {
+      errors.push({
+        lineStart,
+        lineEnd,
+        message: 'Site block has no "reverse_proxy" directive',
+        raw: joinRaw(lines, lineStart, lineEnd),
+      });
+      i = cursor;
+      continue;
+    }
+
+    if (reverseProxyValues.length > 1) {
+      errors.push({
+        lineStart,
+        lineEnd,
+        message: `Site block has ${reverseProxyValues.length} "reverse_proxy" directives; only one is supported`,
+        raw: joinRaw(lines, lineStart, lineEnd),
+      });
+      i = cursor;
+      continue;
+    }
+
+    const upstream = reverseProxyValues[0];
+    if (upstream.length === 0) {
+      errors.push({
+        lineStart,
+        lineEnd,
+        message: '"reverse_proxy" directive is missing an upstream',
+        raw: joinRaw(lines, lineStart, lineEnd),
+      });
+      i = cursor;
+      continue;
+    }
+
+    drafts.push({ domains, upstream, lineStart, lineEnd });
+    i = cursor;
+  }
+
+  return { drafts, errors };
+}

--- a/src/lib/proxy-hosts-import.ts
+++ b/src/lib/proxy-hosts-import.ts
@@ -1,0 +1,78 @@
+/**
+ * Unified import entry point for proxy hosts.
+ *
+ * Auto-detects the input format (Caddyfile vs Caddy runtime JSON) from the
+ * first non-whitespace character and dispatches to the matching pure parser.
+ *
+ * Both parsers emit the same `ImportResult` shape so the server action and UI
+ * can stay format-agnostic.
+ */
+
+import {
+  parseCaddyfile,
+  type CaddyfileImportResult,
+} from "./caddyfile-import";
+import { parseCaddyJson } from "./caddy-json-import";
+
+export type ImportFormat = "caddyfile" | "caddy-json";
+
+export interface ProxyHostImportDraft {
+  domains: string[];
+  upstream: string;
+  /** Defaults to false. Populated by the JSON parser when the upstream uses
+   * Caddy's transport.tls.insecure_skip_verify. */
+  skipHttpsHostnameValidation?: boolean;
+  redirects?: { from: string; to: string; status: 301 | 302 | 307 | 308 }[];
+  locationRules?: { path: string; upstreams: string[] }[];
+  source: { format: ImportFormat; locator: string };
+  warnings?: string[];
+}
+
+export interface ImportError {
+  /** Human-readable location of the error, e.g. "lines 5-9" or "srv2.routes[12]" or "(root)". */
+  locator: string;
+  message: string;
+  /** Optional offending snippet for display. */
+  raw?: string;
+}
+
+export interface ImportSkipped {
+  draft: ProxyHostImportDraft;
+  reason: string;
+}
+
+export interface ImportResult {
+  drafts: ProxyHostImportDraft[];
+  errors: ImportError[];
+  skipped: ImportSkipped[];
+  format: ImportFormat;
+}
+
+function adaptCaddyfileResult(raw: CaddyfileImportResult): ImportResult {
+  return {
+    drafts: raw.drafts.map((d) => ({
+      domains: d.domains,
+      upstream: d.upstream,
+      source: {
+        format: "caddyfile" as const,
+        locator: `lines ${d.lineStart}-${d.lineEnd}`,
+      },
+    })),
+    errors: raw.errors.map((e) => ({
+      locator: `lines ${e.lineStart}-${e.lineEnd}`,
+      message: e.message,
+      raw: e.raw,
+    })),
+    skipped: [],
+    format: "caddyfile",
+  };
+}
+
+export function parseProxyHostsImport(raw: string): ImportResult {
+  // Strip a possible UTF-8 BOM and look at the first non-whitespace character.
+  const cleaned = raw.replace(/^\uFEFF/, "").trimStart();
+  if (cleaned.startsWith("{")) {
+    return parseCaddyJson(cleaned);
+  }
+  return adaptCaddyfileResult(parseCaddyfile(raw));
+}

--- a/tests/fixtures/caddy-json-sample.json
+++ b/tests/fixtures/caddy-json-sample.json
@@ -1,0 +1,134 @@
+{
+  "apps": {
+    "http": {
+      "servers": {
+        "srv_misc": {
+          "listen": [":1882"],
+          "routes": [
+            {
+              "match": [{ "host": ["worksite.test.fr"] }],
+              "handle": [{
+                "handler": "subroute",
+                "routes": [{ "handle": [{
+                  "handler": "reverse_proxy",
+                  "upstreams": [{ "dial": "10.0.0.1:1882" }]
+                }] }]
+              }],
+              "terminal": true
+            }
+          ]
+        },
+        "srv_legacy": {
+          "listen": [":60881"],
+          "routes": [
+            {
+              "match": [{ "host": ["api-old.test.fr"] }],
+              "handle": [{
+                "handler": "subroute",
+                "routes": [{ "handle": [{
+                  "handler": "reverse_proxy",
+                  "upstreams": [{ "dial": "10.0.0.2:1882" }]
+                }] }]
+              }],
+              "terminal": true
+            }
+          ]
+        },
+        "srv_https": {
+          "listen": [":443"],
+          "routes": [
+            {
+              "match": [{ "host": ["worksite.test.fr"] }],
+              "handle": [{
+                "handler": "subroute",
+                "routes": [{ "handle": [{
+                  "handler": "reverse_proxy",
+                  "upstreams": [{ "dial": "10.0.0.1:8080" }]
+                }] }]
+              }],
+              "terminal": true
+            },
+            {
+              "match": [{ "host": ["proxmox.test.fr"] }],
+              "handle": [{
+                "handler": "subroute",
+                "routes": [{ "handle": [{
+                  "handler": "reverse_proxy",
+                  "transport": {
+                    "protocol": "http",
+                    "tls": { "insecure_skip_verify": true }
+                  },
+                  "upstreams": [{ "dial": "10.0.0.3:8006" }]
+                }] }]
+              }],
+              "terminal": true
+            },
+            {
+              "match": [{ "host": ["nextcloud.test.fr"] }],
+              "handle": [{
+                "handler": "subroute",
+                "routes": [
+                  {
+                    "match": [{ "path": ["/.well-known/carddav"] }],
+                    "handle": [{
+                      "handler": "static_response",
+                      "headers": { "Location": ["/remote.php/dav"] },
+                      "status_code": 301
+                    }]
+                  },
+                  {
+                    "handle": [{
+                      "handler": "reverse_proxy",
+                      "upstreams": [{ "dial": "10.0.0.4:80" }]
+                    }]
+                  }
+                ]
+              }],
+              "terminal": true
+            },
+            {
+              "match": [{ "host": ["vaultwarden.test.fr"] }],
+              "handle": [{
+                "handler": "subroute",
+                "routes": [
+                  {
+                    "handle": [{
+                      "handler": "headers",
+                      "response": { "set": { "Strict-Transport-Security": ["max-age=31536000"] } }
+                    }]
+                  },
+                  {
+                    "match": [{ "path": ["/notifications/hub"] }],
+                    "handle": [{
+                      "handler": "reverse_proxy",
+                      "upstreams": [{ "dial": "10.0.0.5:3012" }]
+                    }]
+                  },
+                  {
+                    "handle": [{
+                      "handler": "reverse_proxy",
+                      "upstreams": [{ "dial": "10.0.0.5:80" }]
+                    }]
+                  }
+                ]
+              }],
+              "terminal": true
+            },
+            {
+              "match": [{ "host": ["authportal.test.fr"] }],
+              "handle": [{
+                "handler": "subroute",
+                "routes": [{ "handle": [{
+                  "handler": "authenticator",
+                  "portal_name": "auth-portal",
+                  "route_matcher": "*"
+                }] }]
+              }],
+              "terminal": true
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/caddy-json-import.test.ts
+++ b/tests/unit/caddy-json-import.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Unit tests for src/lib/caddy-json-import.ts
+ * Tests the Caddy runtime JSON parser used by the proxy-host import feature.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseCaddyJson } from '@/lib/caddy-json-import';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('parseCaddyJson', () => {
+  it('reports invalid JSON with a single root-level error', () => {
+    const result = parseCaddyJson('not json');
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].locator).toBe('(root)');
+    expect(result.errors[0].message).toContain('Invalid JSON');
+    expect(result.format).toBe('caddy-json');
+  });
+
+  it('reports a missing apps.http.servers shape error', () => {
+    const result = parseCaddyJson('{}');
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].locator).toBe('(root)');
+    expect(result.errors[0].message).toContain('apps.http.servers');
+  });
+
+  it('reports an error when apps.http.servers is not an object', () => {
+    const result = parseCaddyJson('{"apps":{"http":{"servers":[]}}}');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('apps.http.servers');
+  });
+
+  it('returns an empty result for a valid but empty servers object', () => {
+    const result = parseCaddyJson('{"apps":{"http":{"servers":{}}}}');
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('parses a single simple route into one draft', () => {
+    const input = JSON.stringify({
+      apps: {
+        http: {
+          servers: {
+            srv0: {
+              listen: [':443'],
+              routes: [
+                {
+                  match: [{ host: ['a.test.fr'] }],
+                  handle: [
+                    {
+                      handler: 'subroute',
+                      routes: [
+                        {
+                          handle: [
+                            {
+                              handler: 'reverse_proxy',
+                              upstreams: [{ dial: '10.0.0.1:80' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0]).toMatchObject({
+      domains: ['a.test.fr'],
+      upstream: '10.0.0.1:80',
+      source: { format: 'caddy-json', locator: 'srv0.routes[0]' },
+    });
+  });
+
+  it('parses multiple routes from the same server', () => {
+    const input = JSON.stringify({
+      apps: {
+        http: {
+          servers: {
+            srv0: {
+              listen: [':443'],
+              routes: [
+                {
+                  match: [{ host: ['a.test.fr'] }],
+                  handle: [
+                    {
+                      handler: 'subroute',
+                      routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.1.1.1:80' }] }] }],
+                    },
+                  ],
+                },
+                {
+                  match: [{ host: ['b.test.fr'] }],
+                  handle: [
+                    {
+                      handler: 'subroute',
+                      routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '2.2.2.2:80' }] }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(2);
+    expect(result.drafts.map((d) => d.domains[0])).toEqual(['a.test.fr', 'b.test.fr']);
+    expect(result.drafts.map((d) => d.upstream)).toEqual(['1.1.1.1:80', '2.2.2.2:80']);
+    expect(result.drafts.map((d) => d.source.locator)).toEqual([
+      'srv0.routes[0]',
+      'srv0.routes[1]',
+    ]);
+  });
+
+  it('supports multi-domain routes', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr', 'b.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.2.3.4:80' }] }] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].domains).toEqual(['a.test.fr', 'b.test.fr']);
+  });
+
+  it('flags a route with no host matcher as an error', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{}],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.2.3.4:80' }] }] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].locator).toBe('srv0.routes[0]');
+    expect(result.errors[0].message).toContain('no host matcher');
+  });
+
+  it('maps transport.tls.insecure_skip_verify to skipHttpsHostnameValidation', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [{
+              handler: 'reverse_proxy',
+              transport: { protocol: 'http', tls: { insecure_skip_verify: true } },
+              upstreams: [{ dial: '10.0.0.1:8006' }],
+            }] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].skipHttpsHostnameValidation).toBe(true);
+    // When transport.tls is present, Caddy speaks HTTPS to the backend even if
+    // the dial has no scheme. We prefix https:// so CPM stores the correct
+    // upstream protocol.
+    expect(result.drafts[0].upstream).toBe('https://10.0.0.1:8006');
+  });
+
+  it('does not set skipHttpsHostnameValidation when transport has no TLS', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [{
+              handler: 'reverse_proxy',
+              upstreams: [{ dial: '10.0.0.1:80' }],
+            }] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].skipHttpsHostnameValidation).toBeUndefined();
+    expect(result.drafts[0].upstream).toBe('10.0.0.1:80');
+  });
+
+  it('preserves an upstream dial that already has a scheme', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [{
+              handler: 'reverse_proxy',
+              transport: { protocol: 'http', tls: {} },
+              upstreams: [{ dial: 'https://10.0.0.1:8006' }],
+            }] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts[0].upstream).toBe('https://10.0.0.1:8006');
+  });
+
+  it('maps static_response 3xx with Location header into redirects', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['nextcloud.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [
+              {
+                match: [{ path: ['/.well-known/carddav'] }],
+                handle: [{
+                  handler: 'static_response',
+                  headers: { Location: ['/remote.php/dav'] },
+                  status_code: 301,
+                }],
+              },
+              {
+                handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '10.0.4.110:80' }] }],
+              },
+            ],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].redirects).toEqual([
+      { from: '/.well-known/carddav', to: '/remote.php/dav', status: 301 },
+    ]);
+  });
+
+  it('ignores static_response without a 3xx status or without a Location header', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [
+              {
+                match: [{ path: ['/forbidden'] }],
+                handle: [{ handler: 'static_response', status_code: 403 }],
+              },
+              { handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.2.3.4:80' }] }] },
+            ],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].redirects).toBeUndefined();
+  });
+
+  it('maps path-matched reverse_proxy inner routes to location rules', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['vaultwarden.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [
+              {
+                match: [{ path: ['/notifications/hub'] }],
+                handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '10.0.4.177:3012' }] }],
+              },
+              {
+                handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '10.0.4.177:80' }] }],
+              },
+            ],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].upstream).toBe('10.0.4.177:80');
+    expect(result.drafts[0].locationRules).toEqual([
+      { path: '/notifications/hub', upstreams: ['10.0.4.177:3012'] },
+    ]);
+  });
+
+  it('chooses the unpath-matched reverse_proxy as the primary upstream', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [
+              { handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.1.1.1:80' }] }] },
+              {
+                match: [{ path: ['/api'] }],
+                handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '2.2.2.2:80' }] }],
+              },
+            ],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts[0].upstream).toBe('1.1.1.1:80');
+    expect(result.drafts[0].locationRules).toEqual([
+      { path: '/api', upstreams: ['2.2.2.2:80'] },
+    ]);
+  });
+
+  it('attaches a warning when a route uses the headers handler', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [
+              { handle: [{
+                handler: 'headers',
+                response: { set: { 'Strict-Transport-Security': ['max-age=31536000'] } },
+              }] },
+              { handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.2.3.4:80' }] }] },
+            ],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].warnings).toEqual([
+      'Custom headers ignored; configure HSTS or preserveHostHeader in CPM.',
+    ]);
+  });
+
+  it('attaches a warning when a route uses the authentication handler', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['vaultwarden.test.fr'], path: ['/admin'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [
+              { handler: 'authentication', providers: {} },
+              { handler: 'reverse_proxy', upstreams: [{ dial: '10.0.4.177:80' }] },
+            ] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].warnings).toEqual([
+      'Authentication handler ignored; configure CPM Forward Auth or Authentik manually.',
+    ]);
+  });
+
+  it('skips a route that has only an authenticator handler (auth portal definitions)', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['authportal.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [{
+              handler: 'authenticator',
+              portal_name: 'auth-portal',
+              route_matcher: '*',
+            }] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('no reverse_proxy handler');
+    expect(result.skipped[0].draft.domains).toEqual(['authportal.test.fr']);
+    expect(result.skipped[0].draft.source.locator).toBe('srv0.routes[0]');
+  });
+
+  it('does not warn about encode (silently ignored)', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':443'],
+        routes: [{
+          match: [{ host: ['a.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [
+              { handle: [{ handler: 'encode', encodings: { gzip: {} } }] },
+              { handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.2.3.4:80' }] }] },
+            ],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].warnings).toBeUndefined();
+  });
+
+  it('dedups same domain across ports, :443 winning over other ports', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: {
+        srv0: {
+          listen: [':1882'],
+          routes: [{
+            match: [{ host: ['worksite.test.fr'] }],
+            handle: [{
+              handler: 'subroute',
+              routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '10.0.2.27:1882' }] }] }],
+            }],
+          }],
+        },
+        srv1: {
+          listen: [':443'],
+          routes: [{
+            match: [{ host: ['worksite.test.fr'] }],
+            handle: [{
+              handler: 'subroute',
+              routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '10.0.2.27:8080' }] }] }],
+            }],
+          }],
+        },
+      } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].upstream).toBe('10.0.2.27:8080');
+    expect(result.drafts[0].source.locator).toBe('srv1.routes[0]');
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('superseded by :443 server');
+    expect(result.skipped[0].draft.upstream).toBe('10.0.2.27:1882');
+  });
+
+  it('keeps a draft that lives only on a non-443 port', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: { srv0: {
+        listen: [':60881'],
+        routes: [{
+          match: [{ host: ['api-old.test.fr'] }],
+          handle: [{
+            handler: 'subroute',
+            routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '10.0.2.69:1882' }] }] }],
+          }],
+        }],
+      } } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].upstream).toBe('10.0.2.69:1882');
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('non-:443 second occurrence loses to non-:443 first occurrence', () => {
+    const input = JSON.stringify({
+      apps: { http: { servers: {
+        srv0: {
+          listen: [':1882'],
+          routes: [{
+            match: [{ host: ['a.test.fr'] }],
+            handle: [{
+              handler: 'subroute',
+              routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '1.1.1.1:80' }] }] }],
+            }],
+          }],
+        },
+        srv1: {
+          listen: [':1883'],
+          routes: [{
+            match: [{ host: ['a.test.fr'] }],
+            handle: [{
+              handler: 'subroute',
+              routes: [{ handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '2.2.2.2:80' }] }] }],
+            }],
+          }],
+        },
+      } } },
+    });
+    const result = parseCaddyJson(input);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].upstream).toBe('1.1.1.1:80');
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].draft.upstream).toBe('2.2.2.2:80');
+    expect(result.skipped[0].reason).toBe('superseded by :1882 server');
+  });
+
+  it('parses the representative fixture into the expected drafts and skipped entries', () => {
+    const fixturePath = resolve(__dirname, '..', 'fixtures', 'caddy-json-sample.json');
+    const raw = readFileSync(fixturePath, 'utf-8');
+    const result = parseCaddyJson(raw);
+
+    expect(result.errors).toEqual([]);
+
+    // 5 drafts: worksite.test.fr (:443 wins), api-old (only :60881), proxmox, nextcloud, vaultwarden
+    expect(result.drafts.map((d) => d.domains[0])).toEqual([
+      'worksite.test.fr',
+      'api-old.test.fr',
+      'proxmox.test.fr',
+      'nextcloud.test.fr',
+      'vaultwarden.test.fr',
+    ]);
+
+    const byDomain = Object.fromEntries(result.drafts.map((d) => [d.domains[0], d]));
+
+    expect(byDomain['worksite.test.fr'].upstream).toBe('10.0.0.1:8080');
+    expect(byDomain['worksite.test.fr'].source.locator).toBe('srv_https.routes[0]');
+
+    expect(byDomain['proxmox.test.fr'].upstream).toBe('https://10.0.0.3:8006');
+    expect(byDomain['proxmox.test.fr'].skipHttpsHostnameValidation).toBe(true);
+
+    expect(byDomain['nextcloud.test.fr'].upstream).toBe('10.0.0.4:80');
+    expect(byDomain['nextcloud.test.fr'].redirects).toEqual([
+      { from: '/.well-known/carddav', to: '/remote.php/dav', status: 301 },
+    ]);
+
+    expect(byDomain['vaultwarden.test.fr'].upstream).toBe('10.0.0.5:80');
+    expect(byDomain['vaultwarden.test.fr'].locationRules).toEqual([
+      { path: '/notifications/hub', upstreams: ['10.0.0.5:3012'] },
+    ]);
+    expect(byDomain['vaultwarden.test.fr'].warnings).toEqual([
+      'Custom headers ignored; configure HSTS or preserveHostHeader in CPM.',
+    ]);
+
+    // Skipped: worksite.test.fr (:1882) superseded by :443; authportal.test.fr (no reverse_proxy).
+    expect(result.skipped).toHaveLength(2);
+    const skippedByDomain = Object.fromEntries(
+      result.skipped.map((s) => [s.draft.domains[0], s])
+    );
+    expect(skippedByDomain['worksite.test.fr'].reason).toBe('superseded by :443 server');
+    expect(skippedByDomain['authportal.test.fr'].reason).toBe('no reverse_proxy handler');
+  });
+});

--- a/tests/unit/caddyfile-import.test.ts
+++ b/tests/unit/caddyfile-import.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for src/lib/caddyfile-import.ts
+ * Tests the pure Caddyfile parser used by the proxy-host import feature.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseCaddyfile } from '@/src/lib/caddyfile-import';
+
+describe('parseCaddyfile', () => {
+  it('returns no drafts and no errors for empty input', () => {
+    const result = parseCaddyfile('');
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('returns no drafts and no errors for whitespace-only input', () => {
+    const result = parseCaddyfile('   \n\n\t\n');
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('parses a single site block with one reverse_proxy', () => {
+    const input = `demo-test.test.fr {
+        reverse_proxy 10.0.0.27:8080
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0]).toEqual({
+      domains: ['demo-test.test.fr'],
+      upstream: '10.0.0.27:8080',
+      lineStart: 1,
+      lineEnd: 3,
+    });
+  });
+
+  it('parses the three-block example from the spec', () => {
+    const input = `demo-test.test.fr {
+        reverse_proxy 10.0.0.27:8080
+}
+
+demo-prod.test.fr {
+        reverse_proxy 10.0.0.27:1882
+}
+
+demo-dev.test.fr {
+        reverse_proxy 10.0.0.29:3000
+}
+`;
+    const result = parseCaddyfile(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(3);
+    expect(result.drafts.map((d) => d.domains[0])).toEqual([
+      'demo-test.test.fr',
+      'demo-prod.test.fr',
+      'demo-dev.test.fr',
+    ]);
+    expect(result.drafts.map((d) => d.upstream)).toEqual([
+      '10.0.0.27:8080',
+      '10.0.0.27:1882',
+      '10.0.0.29:3000',
+    ]);
+  });
+
+  it('supports multi-domain site blocks (comma-separated)', () => {
+    const input = `a.test.fr, b.test.fr {
+  reverse_proxy 10.0.0.1:80
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].domains).toEqual(['a.test.fr', 'b.test.fr']);
+  });
+
+  it('ignores # comments inside and outside blocks', () => {
+    const input = `# top-level comment
+a.test.fr {
+  # inline comment
+  reverse_proxy 1.2.3.4:80
+}
+# trailing comment
+`;
+    const result = parseCaddyfile(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].upstream).toBe('1.2.3.4:80');
+  });
+
+  it('accepts opening brace on the next line', () => {
+    const input = `a.test.fr
+{
+  reverse_proxy 1.2.3.4:80
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+  });
+
+  it('passes port-only upstreams through verbatim', () => {
+    const input = `a.test.fr {
+  reverse_proxy :1882
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts[0].upstream).toBe(':1882');
+  });
+
+  it('flags unsupported directives and rejects the block', () => {
+    const input = `a.test.fr {
+  tls admin@example.com
+  reverse_proxy 1.2.3.4:80
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('Unsupported directive');
+    expect(result.errors[0].message).toContain('tls');
+  });
+
+  it('flags a block with no reverse_proxy directive', () => {
+    const input = `a.test.fr {
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('no "reverse_proxy"');
+  });
+
+  it('flags a block with multiple reverse_proxy directives', () => {
+    const input = `a.test.fr {
+  reverse_proxy 1.2.3.4:80
+  reverse_proxy 5.6.7.8:80
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('only one is supported');
+  });
+
+  it('flags an unclosed block', () => {
+    const input = `a.test.fr {
+  reverse_proxy 1.2.3.4:80
+`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('missing closing');
+  });
+
+  it('flags an empty domain list', () => {
+    const input = ` {
+  reverse_proxy 1.2.3.4:80
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('Empty domain list');
+  });
+
+  it('returns valid drafts alongside errors (partial success)', () => {
+    const input = `a.test.fr {
+  reverse_proxy 1.2.3.4:80
+}
+
+bad.test.fr {
+  tls something
+  reverse_proxy 5.6.7.8:80
+}
+
+c.test.fr {
+  reverse_proxy 9.9.9.9:80
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts.map((d) => d.domains[0])).toEqual(['a.test.fr', 'c.test.fr']);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('tls');
+  });
+
+  it('rejects single-line blocks with closing brace on the same line (v1 scope)', () => {
+    const input = `a.test.fr { reverse_proxy 1.2.3.4:80 }`;
+    const result = parseCaddyfile(input);
+    // v1 only supports multi-line blocks; the closing "}" must be on its own line.
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('Single-line blocks are not supported');
+  });
+
+  it('strips a leading UTF-8 BOM before parsing', () => {
+    const input = '﻿a.test.fr {\n  reverse_proxy 1.2.3.4:80\n}';
+    const result = parseCaddyfile(input);
+    expect(result.errors).toEqual([]);
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].domains).toEqual(['a.test.fr']);
+  });
+
+  it('rejects multi-upstream reverse_proxy lines', () => {
+    const input = `a.test.fr {
+  reverse_proxy 1.2.3.4:80 5.6.7.8:80
+}`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('multi-upstream');
+  });
+
+  it('flags single-line blocks with a specific message (not just missing brace)', () => {
+    const input = `a.test.fr { reverse_proxy 1.2.3.4:80 }`;
+    const result = parseCaddyfile(input);
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('Single-line blocks');
+  });
+});

--- a/tests/unit/proxy-hosts-import.test.ts
+++ b/tests/unit/proxy-hosts-import.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for src/lib/proxy-hosts-import.ts
+ * Tests the dispatcher that routes to the JSON or Caddyfile parser based on input shape.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseProxyHostsImport } from '@/lib/proxy-hosts-import';
+
+describe('parseProxyHostsImport', () => {
+  it('returns an empty Caddyfile result for empty input', () => {
+    const result = parseProxyHostsImport('');
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.format).toBe('caddyfile');
+  });
+
+  it('dispatches to the Caddyfile parser for non-JSON input', () => {
+    const input = `a.test.fr {
+  reverse_proxy 1.2.3.4:80
+}`;
+    const result = parseProxyHostsImport(input);
+    expect(result.format).toBe('caddyfile');
+    expect(result.drafts).toHaveLength(1);
+    expect(result.drafts[0].domains).toEqual(['a.test.fr']);
+    expect(result.drafts[0].upstream).toBe('1.2.3.4:80');
+    expect(result.drafts[0].source).toEqual({
+      format: 'caddyfile',
+      locator: 'lines 1-3',
+    });
+  });
+
+  it('adapts Caddyfile parse errors to the unified ImportError shape', () => {
+    const input = `a.test.fr {
+  tls foo@bar
+  reverse_proxy 1.2.3.4:80
+}`;
+    const result = parseProxyHostsImport(input);
+    expect(result.format).toBe('caddyfile');
+    expect(result.drafts).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].locator).toMatch(/lines \d+-\d+/);
+    expect(result.errors[0].message).toContain('Unsupported directive');
+  });
+
+  it('dispatches to the JSON parser when input starts with "{"', () => {
+    const input = '{"apps":{}}';
+    const result = parseProxyHostsImport(input);
+    expect(result.format).toBe('caddy-json');
+  });
+
+  it('dispatches to the JSON parser when input has leading whitespace then "{"', () => {
+    const input = '   \n\t{"apps":{}}';
+    const result = parseProxyHostsImport(input);
+    expect(result.format).toBe('caddy-json');
+  });
+
+  it('dispatches to the JSON parser when input starts with a UTF-8 BOM then "{"', () => {
+    const input = '\uFEFF{"apps":{"http":{"servers":{}}}}';
+    const result = parseProxyHostsImport(input);
+    expect(result.format).toBe('caddy-json');
+    expect(result.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds a bulk import feature for proxy hosts. Admins can paste or upload either:
- a minimal Caddyfile (`site { reverse_proxy upstream }` blocks), or
- a Caddy runtime JSON config (e.g. `curl localhost:2019/config/`).

The format is auto-detected. A 3-step dialog (input → preview → result) shows
detected hosts with conflict and skip flags before creating anything.

The JSON parser maps `transport.tls.insecure_skip_verify` to skip-hostname-validation,
`static_response` 3xx to redirect rules, and path-matched routes to location rules.
Routes with unmappable directives (custom headers, auth handlers) get warnings.
When the same domain appears on multiple ports, :443 wins.