### PR TITLE
feat: make ClickHouse retention configurable, default 30 days

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,7 +113,7 @@ OAUTH_ALLOW_AUTO_LINKING=false         # Auto-link OAuth to accounts without pas
 
 # Comma-separated list of profiles to activate.
 # Available profiles:
-#   clickhouse   — ClickHouse analytics database (traffic + WAF events, 90-day TTL)
+#   clickhouse   — ClickHouse analytics database (traffic + WAF events, 30-day TTL)
 #   geoipupdate  — Automatic MaxMind GeoLite2 database updates (required for geo blocking)
 #
 # To disable analytics, remove "clickhouse" from this list (or leave it empty).
@@ -130,6 +130,11 @@ CLICKHOUSE_PASSWORD=your-clickhouse-password-here
 # CLICKHOUSE_URL=http://clickhouse:8123
 # CLICKHOUSE_USER=cpm
 # CLICKHOUSE_DB=analytics
+
+# How long analytics events (traffic + WAF) are retained before ClickHouse's
+# TTL deletes them. Defaults to 30 days. Lower this to use less disk space.
+# Changing it migrates the existing tables' TTL on the next startup.
+# CLICKHOUSE_RETENTION_DAYS=30
 
 # =============================================================================
 # GEOIP UPDATE (OPTIONAL)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Web interface for managing [Caddy Server](https://caddyserver.com/) reverse prox
 
 ## Overview
 
-This project provides a web UI for Caddy Server, eliminating the need to manually edit JSON configurations or Caddyfiles. It handles reverse proxies, access lists, and certificate management through a shadcn/ui interface. Built with Next.js 16, React 19, shadcn/ui, Tailwind CSS, Drizzle ORM, and TypeScript. Analytics data (traffic events, WAF events) is stored in ClickHouse for fast aggregation queries, with automatic 90-day retention via TTL.
+This project provides a web UI for Caddy Server, eliminating the need to manually edit JSON configurations or Caddyfiles. It handles reverse proxies, access lists, and certificate management through a shadcn/ui interface. Built with Next.js 16, React 19, shadcn/ui, Tailwind CSS, Drizzle ORM, and TypeScript. Analytics data (traffic events, WAF events) is stored in ClickHouse for fast aggregation queries, with automatic retention via TTL (30 days by default, configurable).
 
 ---
 
@@ -203,7 +203,7 @@ The databases are stored in the `geoip-data` Docker volume and shared between th
 
 ## Analytics
 
-Analytics uses a bundled ClickHouse instance for storing and querying traffic events and WAF events. Data is retained for **90 days** via ClickHouse's TTL.
+Analytics uses a bundled ClickHouse instance for storing and querying traffic events and WAF events. Data is retained for **30 days** by default via ClickHouse's TTL. Change the window with the `CLICKHOUSE_RETENTION_DAYS` environment variable — on the next startup the existing tables' TTL is migrated to the new value and expired data is purged.
 
 ### Enabling analytics (recommended)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-cpm}
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
       CLICKHOUSE_DB: ${CLICKHOUSE_DB:-analytics}
+      # Days of analytics data to keep before TTL deletes it (default 30)
+      CLICKHOUSE_RETENTION_DAYS: ${CLICKHOUSE_RETENTION_DAYS:-30}
     group_add:
       - "${CADDY_GID:-10000}"  # caddy's GID — lets the web user read /logs/access.log
     volumes:

--- a/src/lib/clickhouse/client.ts
+++ b/src/lib/clickhouse/client.ts
@@ -12,6 +12,21 @@ if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(CH_DB)) {
   throw new Error(`CLICKHOUSE_DB contains invalid characters: ${CH_DB}`);
 }
 
+const DEFAULT_RETENTION_DAYS = 30;
+
+/** Parse CLICKHOUSE_RETENTION_DAYS into a positive integer number of days. */
+function parseRetentionDays(raw: string | undefined): number {
+  if (raw == null || raw.trim() === '') return DEFAULT_RETENTION_DAYS;
+  const n = Number(raw.trim());
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`CLICKHOUSE_RETENTION_DAYS must be a positive integer (got: ${raw})`);
+  }
+  return n;
+}
+
+// Number of days analytics events are kept before ClickHouse's TTL deletes them.
+const CH_RETENTION_DAYS = parseRetentionDays(process.env.CLICKHOUSE_RETENTION_DAYS);
+
 // ── Analytics state ─────────────────────────────────────────────────────────
 
 const analyticsConfigured = CH_PASS.trim().length > 0;
@@ -19,6 +34,11 @@ const analyticsConfigured = CH_PASS.trim().length > 0;
 /** Returns true when ClickHouse analytics is configured for this process. */
 export function isAnalyticsEnabled(): boolean {
   return analyticsConfigured;
+}
+
+/** Number of days analytics events are retained before TTL deletion. */
+export function getRetentionDays(): number {
+  return CH_RETENTION_DAYS;
 }
 
 // ── Singleton client ────────────────────────────────────────────────────────
@@ -63,7 +83,7 @@ CREATE TABLE IF NOT EXISTS traffic_events (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(ts)
 ORDER BY (host, ts)
-TTL ts + INTERVAL 90 DAY DELETE
+TTL ts + INTERVAL ${CH_RETENTION_DAYS} DAY DELETE
 SETTINGS index_granularity = 8192
 `;
 
@@ -83,7 +103,7 @@ CREATE TABLE IF NOT EXISTS waf_events (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(ts)
 ORDER BY (host, ts)
-TTL ts + INTERVAL 90 DAY DELETE
+TTL ts + INTERVAL ${CH_RETENTION_DAYS} DAY DELETE
 SETTINGS index_granularity = 8192
 `;
 
@@ -112,6 +132,41 @@ const WAF_EVENTS_MIGRATIONS = [
   `ALTER TABLE waf_events MODIFY COLUMN raw_data Nullable(String) CODEC(ZSTD(3))`,
 ];
 
+const RETENTION_TABLES = ['traffic_events', 'waf_events'] as const;
+
+/** Extract the retention (in days) from a table's TTL clause, if present. */
+function ttlDaysFromCreateQuery(createQuery: string): number | null {
+  // ClickHouse normalizes `INTERVAL N DAY` to `toIntervalDay(N)` in create_table_query,
+  // but older servers may report the literal form — match both.
+  const match =
+    createQuery.match(/TTL\s+ts\s*\+\s*toIntervalDay\((\d+)\)/i) ??
+    createQuery.match(/TTL\s+ts\s*\+\s*INTERVAL\s+(\d+)\s+DAY/i);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Bring an existing table's TTL in line with CH_RETENTION_DAYS.
+ *
+ * `CREATE TABLE IF NOT EXISTS` never alters an existing table, so deployments
+ * created under a different retention keep their old TTL forever unless we
+ * issue an explicit MODIFY TTL. We only do so when the current TTL differs,
+ * since MODIFY TTL materializes a mutation that rewrites parts to drop expired
+ * rows — cheap to skip, wasteful to repeat on every restart.
+ */
+async function ensureRetentionTtl(ch: ClickHouseClient, table: (typeof RETENTION_TABLES)[number]): Promise<void> {
+  const result = await ch.query({
+    query: `SELECT create_table_query FROM system.tables WHERE database = {db:String} AND name = {tbl:String}`,
+    query_params: { db: CH_DB, tbl: table },
+    format: 'JSONEachRow',
+  });
+  const rows = await result.json<{ create_table_query: string }>();
+  const current = ttlDaysFromCreateQuery(rows[0]?.create_table_query ?? '');
+  if (current === CH_RETENTION_DAYS) return;
+  await ch.command({
+    query: `ALTER TABLE ${table} MODIFY TTL ts + INTERVAL ${CH_RETENTION_DAYS} DAY DELETE`,
+  });
+}
+
 export async function initClickHouse(): Promise<void> {
   if (!analyticsConfigured) {
     console.log('ClickHouse analytics disabled (CLICKHOUSE_PASSWORD not set)');
@@ -123,6 +178,9 @@ export async function initClickHouse(): Promise<void> {
   await ch.command({ query: WAF_EVENTS_DDL });
   for (const q of [...TRAFFIC_EVENTS_MIGRATIONS, ...WAF_EVENTS_MIGRATIONS]) {
     await ch.command({ query: q });
+  }
+  for (const table of RETENTION_TABLES) {
+    await ensureRetentionTtl(ch, table);
   }
 }
 

--- a/src/lib/clickhouse/init.sql
+++ b/src/lib/clickhouse/init.sql
@@ -1,6 +1,10 @@
 -- Reference DDL for ClickHouse analytics tables.
 -- Tables are created programmatically by client.ts initClickHouse().
 -- This file is for documentation only.
+--
+-- The TTL retention window below is the default (30 days). At runtime it is
+-- driven by the CLICKHOUSE_RETENTION_DAYS environment variable, and existing
+-- tables are migrated to the configured value on startup.
 
 CREATE TABLE IF NOT EXISTS traffic_events (
     ts           DateTime          CODEC(Delta, ZSTD),
@@ -17,7 +21,7 @@ CREATE TABLE IF NOT EXISTS traffic_events (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(ts)
 ORDER BY (host, ts)
-TTL ts + INTERVAL 90 DAY DELETE
+TTL ts + INTERVAL 30 DAY DELETE
 SETTINGS index_granularity = 8192;
 
 CREATE TABLE IF NOT EXISTS waf_events (
@@ -35,5 +39,5 @@ CREATE TABLE IF NOT EXISTS waf_events (
 ) ENGINE = MergeTree()
 PARTITION BY toYYYYMM(ts)
 ORDER BY (host, ts)
-TTL ts + INTERVAL 90 DAY DELETE
+TTL ts + INTERVAL 30 DAY DELETE
 SETTINGS index_granularity = 8192;

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -22,6 +22,9 @@ services:
   clickhouse:
     environment:
       CLICKHOUSE_PASSWORD: "test-clickhouse-password-2026"
+    # Expose the HTTP interface so retention/TTL e2e tests can query directly.
+    ports:
+      - "8123:8123"
   caddy:
     ports:
       - "80:80"

--- a/tests/e2e/clickhouse-retention.spec.ts
+++ b/tests/e2e/clickhouse-retention.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test';
+import { createClient, type ClickHouseClient } from '@clickhouse/client';
+
+// The web container creates the tables with this TTL on startup. The test stack
+// leaves CLICKHOUSE_RETENTION_DAYS unset, so both default to 30.
+const RETENTION_DAYS = Number(process.env.CLICKHOUSE_RETENTION_DAYS ?? 30);
+const DAY_SECONDS = 86_400;
+
+// ClickHouse HTTP port is exposed to the host by tests/docker-compose.test.yml.
+function makeClient(): ClickHouseClient {
+  return createClient({
+    url: 'http://localhost:8123',
+    username: 'cpm',
+    password: 'test-clickhouse-password-2026',
+    database: 'analytics',
+  });
+}
+
+function chDateTime(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toISOString().replace('T', ' ').slice(0, 19);
+}
+
+async function countRows(
+  ch: ClickHouseClient,
+  table: 'traffic_events' | 'waf_events',
+  host: string,
+  beforeTs?: number,
+): Promise<number> {
+  const clauses = ['host = {h:String}'];
+  const params: Record<string, unknown> = { h: host };
+  if (beforeTs != null) {
+    clauses.push('ts < toDateTime({t:UInt32})');
+    params.t = beforeTs;
+  }
+  const result = await ch.query({
+    query: `SELECT count() AS c FROM ${table} WHERE ${clauses.join(' AND ')}`,
+    query_params: params,
+    format: 'JSONEachRow',
+  });
+  const rows = await result.json<{ c: string }>();
+  return Number(rows[0]?.c ?? 0);
+}
+
+// TTL deletion is lazy (background merges). Force it synchronously so the test
+// is deterministic: MATERIALIZE TTL recomputes TTL info and drops expired rows,
+// and mutations_sync=2 makes the command block until that mutation finishes.
+async function forceTtl(ch: ClickHouseClient, table: 'traffic_events' | 'waf_events'): Promise<void> {
+  await ch.command({ query: `ALTER TABLE ${table} MATERIALIZE TTL SETTINGS mutations_sync = 2` });
+  await ch.command({ query: `OPTIMIZE TABLE ${table} FINAL` });
+}
+
+test.describe('ClickHouse retention TTL', () => {
+  test('tables carry the configured retention TTL', async () => {
+    const ch = makeClient();
+    try {
+      for (const table of ['traffic_events', 'waf_events'] as const) {
+        const result = await ch.query({
+          query: `SELECT create_table_query FROM system.tables WHERE database = 'analytics' AND name = {tbl:String}`,
+          query_params: { tbl: table },
+          format: 'JSONEachRow',
+        });
+        const rows = await result.json<{ create_table_query: string }>();
+        const ddl = rows[0]?.create_table_query ?? '';
+        expect(ddl, `${table} should have a TTL`).toMatch(
+          new RegExp(`toIntervalDay\\(${RETENTION_DAYS}\\)|INTERVAL ${RETENTION_DAYS} DAY`),
+        );
+      }
+    } finally {
+      await ch.close();
+    }
+  });
+
+  test('purges traffic events past the retention window and keeps recent ones', async () => {
+    const ch = makeClient();
+    const marker = `ttl-traffic-${Date.now()}.example.com`;
+    const nowSec = Math.floor(Date.now() / 1000);
+    const retentionBoundary = nowSec - RETENTION_DAYS * DAY_SECONDS;
+    const expiredTs = nowSec - (RETENTION_DAYS + 10) * DAY_SECONDS;
+    const freshTs = nowSec - DAY_SECONDS;
+
+    try {
+      await ch.insert({
+        table: 'traffic_events',
+        format: 'JSONEachRow',
+        values: [
+          { ts: chDateTime(expiredTs), client_ip: '203.0.113.1', host: marker, method: 'GET', uri: '/expired', status: 200, proto: 'HTTP/1.1', bytes_sent: 1, user_agent: 'ttl-test', is_blocked: 0 },
+          { ts: chDateTime(freshTs), client_ip: '203.0.113.2', host: marker, method: 'GET', uri: '/fresh', status: 200, proto: 'HTTP/1.1', bytes_sent: 1, user_agent: 'ttl-test', is_blocked: 0 },
+        ],
+      });
+
+      expect(await countRows(ch, 'traffic_events', marker)).toBe(2);
+
+      await forceTtl(ch, 'traffic_events');
+
+      expect(await countRows(ch, 'traffic_events', marker, retentionBoundary)).toBe(0);
+      expect(await countRows(ch, 'traffic_events', marker)).toBe(1);
+    } finally {
+      await ch.command({
+        query: `ALTER TABLE traffic_events DELETE WHERE host = {h:String} SETTINGS mutations_sync = 2`,
+        query_params: { h: marker },
+      }).catch(() => { /* best-effort cleanup */ });
+      await ch.close();
+    }
+  });
+
+  test('purges WAF events past the retention window and keeps recent ones', async () => {
+    const ch = makeClient();
+    const marker = `ttl-waf-${Date.now()}.example.com`;
+    const nowSec = Math.floor(Date.now() / 1000);
+    const retentionBoundary = nowSec - RETENTION_DAYS * DAY_SECONDS;
+    const expiredTs = nowSec - (RETENTION_DAYS + 10) * DAY_SECONDS;
+    const freshTs = nowSec - DAY_SECONDS;
+
+    try {
+      await ch.insert({
+        table: 'waf_events',
+        format: 'JSONEachRow',
+        values: [
+          { ts: chDateTime(expiredTs), host: marker, client_ip: '203.0.113.1', method: 'GET', uri: '/expired', rule_id: 1, blocked: 1 },
+          { ts: chDateTime(freshTs), host: marker, client_ip: '203.0.113.2', method: 'GET', uri: '/fresh', rule_id: 1, blocked: 1 },
+        ],
+      });
+
+      expect(await countRows(ch, 'waf_events', marker)).toBe(2);
+
+      await forceTtl(ch, 'waf_events');
+
+      expect(await countRows(ch, 'waf_events', marker, retentionBoundary)).toBe(0);
+      expect(await countRows(ch, 'waf_events', marker)).toBe(1);
+    } finally {
+      await ch.command({
+        query: `ALTER TABLE waf_events DELETE WHERE host = {h:String} SETTINGS mutations_sync = 2`,
+        query_params: { h: marker },
+      }).catch(() => { /* best-effort cleanup */ });
+      await ch.close();
+    }
+  });
+});

--- a/tests/e2e/clickhouse-retention.spec.ts
+++ b/tests/e2e/clickhouse-retention.spec.ts
@@ -88,8 +88,11 @@ test.describe('ClickHouse retention TTL', () => {
         ],
       });
 
-      expect(await countRows(ch, 'traffic_events', marker)).toBe(2);
-
+      // Don't assert both rows are visible here: ClickHouse schedules a TTL
+      // merge as soon as it ingests a part containing already-expired rows, so a
+      // count() right after insert races that merge (and reads filter expired
+      // rows before physical removal anyway). Force the purge deterministically,
+      // then assert only the fresh row survives.
       await forceTtl(ch, 'traffic_events');
 
       expect(await countRows(ch, 'traffic_events', marker, retentionBoundary)).toBe(0);
@@ -121,8 +124,8 @@ test.describe('ClickHouse retention TTL', () => {
         ],
       });
 
-      expect(await countRows(ch, 'waf_events', marker)).toBe(2);
-
+      // See the traffic_events test: count() right after insert races the TTL
+      // merge ClickHouse schedules for expired rows, so we don't assert it here.
       await forceTtl(ch, 'waf_events');
 
       expect(await countRows(ch, 'waf_events', marker, retentionBoundary)).toBe(0);

--- a/tests/integration/clickhouse-client.test.ts
+++ b/tests/integration/clickhouse-client.test.ts
@@ -64,6 +64,64 @@ describe('clickhouse client analytics enablement', () => {
     expect(createClient).not.toHaveBeenCalled();
   });
 
+  it('defaults retention to 30 days and creates tables with a 30-day TTL', async () => {
+    vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
+    vi.stubEnv('CLICKHOUSE_RETENTION_DAYS', '');
+
+    const commands: string[] = [];
+    const command = vi.fn(async ({ query }: { query: string }) => { commands.push(query); });
+    // ensureRetentionTtl reads the live TTL; report it already matches 30 days.
+    const query = vi.fn(async () => ({ json: async () => [{ create_table_query: 'TTL ts + toIntervalDay(30)' }] }));
+
+    vi.doMock('@clickhouse/client', () => ({
+      createClient: vi.fn(() => ({ query, command, insert: vi.fn(), close: vi.fn() })),
+    }));
+
+    const { getRetentionDays, initClickHouse } = await import('@/src/lib/clickhouse/client');
+    expect(getRetentionDays()).toBe(30);
+
+    await initClickHouse();
+
+    const trafficDdl = commands.find(q => q.includes('CREATE TABLE IF NOT EXISTS traffic_events'));
+    const wafDdl = commands.find(q => q.includes('CREATE TABLE IF NOT EXISTS waf_events'));
+    expect(trafficDdl).toContain('TTL ts + INTERVAL 30 DAY DELETE');
+    expect(wafDdl).toContain('TTL ts + INTERVAL 30 DAY DELETE');
+    // TTL already matches → no MODIFY TTL migration issued.
+    expect(commands.some(q => q.includes('MODIFY TTL'))).toBe(false);
+  });
+
+  it('honors a custom retention value and migrates an existing table whose TTL differs', async () => {
+    vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
+    vi.stubEnv('CLICKHOUSE_RETENTION_DAYS', '7');
+
+    const commands: string[] = [];
+    const command = vi.fn(async ({ query }: { query: string }) => { commands.push(query); });
+    // Existing tables were created under the old 90-day TTL.
+    const query = vi.fn(async () => ({ json: async () => [{ create_table_query: 'TTL ts + toIntervalDay(90)' }] }));
+
+    vi.doMock('@clickhouse/client', () => ({
+      createClient: vi.fn(() => ({ query, command, insert: vi.fn(), close: vi.fn() })),
+    }));
+
+    const { getRetentionDays, initClickHouse } = await import('@/src/lib/clickhouse/client');
+    expect(getRetentionDays()).toBe(7);
+
+    await initClickHouse();
+
+    expect(commands.find(q => q.includes('CREATE TABLE IF NOT EXISTS traffic_events')))
+      .toContain('TTL ts + INTERVAL 7 DAY DELETE');
+    const modifies = commands.filter(q => /ALTER TABLE \w+ MODIFY TTL ts \+ INTERVAL 7 DAY DELETE/.test(q));
+    expect(modifies).toHaveLength(2);
+  });
+
+  it('throws when CLICKHOUSE_RETENTION_DAYS is not a positive integer', async () => {
+    vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
+    vi.stubEnv('CLICKHOUSE_RETENTION_DAYS', 'not-a-number');
+    vi.doMock('@clickhouse/client', () => ({ createClient: vi.fn() }));
+
+    await expect(import('@/src/lib/clickhouse/client')).rejects.toThrow(/CLICKHOUSE_RETENTION_DAYS/);
+  });
+
   it('returns full WAF stats for the filtered result set', async () => {
     vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
 


### PR DESCRIPTION
Add CLICKHOUSE_RETENTION_DAYS (default 30, was a hardcoded 90-day TTL) and
migrate existing tables' TTL on startup so the configured window actually
takes effect on upgraded deployments instead of being frozen at table
creation. Add e2e tests verifying expired rows are purged while recent
rows are retained.

https://claude.ai/code/session_01ERHcYFzcAePm4etYyXykuQ