### PR TITLE
Add custom error pages support (per-host and global)

### DIFF
--- a/app/(dashboard)/proxy-hosts/actions.ts
+++ b/app/(dashboard)/proxy-hosts/actions.ts
@@ -20,8 +20,10 @@ import {
   type PathAllowRule,
   type PathBlockRule,
   type PathRewriteRule,
+  type ErrorPageRule,
   type CpmForwardAuthInput,
-  PATH_BLOCK_STATUS_CODES
+  PATH_BLOCK_STATUS_CODES,
+  sanitizeErrorPageRules
 } from "@/src/lib/models/proxy-hosts";
 import { getCertificate } from "@/src/lib/models/certificates";
 import { setForwardAuthAccess } from "@/src/lib/models/forward-auth";
@@ -528,6 +530,16 @@ function parsePathRewritesConfig(formData: FormData): PathRewriteRule[] | null {
   }
 }
 
+function parseErrorPagesConfig(formData: FormData): ErrorPageRule[] | null {
+  const raw = formData.get("errorPagesJson");
+  if (!raw || typeof raw !== "string") return null;
+  try {
+    return sanitizeErrorPageRules(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
 function parseUpstreamDnsResolutionConfig(formData: FormData): UpstreamDnsResolutionInput | undefined {
   if (!formData.has("upstreamDnsResolutionPresent")) {
     return undefined;
@@ -605,6 +617,7 @@ export async function createProxyHostAction(
         pathAllows: parsePathAllowsConfig(formData),
         pathBlocks: parsePathBlocksConfig(formData),
         pathRewrites: parsePathRewritesConfig(formData),
+        errorPages: parseErrorPagesConfig(formData),
       },
       userId
     );
@@ -694,6 +707,7 @@ export async function updateProxyHostAction(
         pathAllows: formData.has("pathAllowsJson") ? parsePathAllowsConfig(formData) : undefined,
         pathBlocks: formData.has("pathBlocksJson") ? parsePathBlocksConfig(formData) : undefined,
         pathRewrites: formData.has("pathRewritesJson") ? parsePathRewritesConfig(formData) : undefined,
+        errorPages: formData.has("errorPagesJson") ? parseErrorPagesConfig(formData) : undefined,
       },
       userId
     );

--- a/app/(dashboard)/settings/SettingsClient.tsx
+++ b/app/(dashboard)/settings/SettingsClient.tsx
@@ -4,7 +4,7 @@ import { useState, useActionState, useEffect, type ReactNode } from "react";
 import {
   Cloud, Globe, Network, Pin, Activity,
   ScrollText, Settings2, UserCheck, MapPin, KeyRound,
-  Search, ChevronRight,
+  Search, ChevronRight, FileWarning,
 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -33,9 +33,11 @@ import type {
   DnsProviderSettings,
   UpstreamDnsResolutionSettings,
   GeoBlockSettings,
+  ErrorPagesSettings,
 } from "@/lib/settings";
 import type { DnsProviderDefinition } from "@/src/lib/dns-providers";
 import { GeoBlockFields } from "@/components/proxy-hosts/GeoBlockFields";
+import { ErrorPagesFields } from "@/components/proxy-hosts/ErrorPagesFields";
 import OAuthProvidersSection from "./OAuthProvidersSection";
 import type { OAuthProvider } from "@/src/lib/models/oauth-providers";
 import {
@@ -53,6 +55,7 @@ import {
   toggleSlaveInstanceAction,
   syncSlaveInstancesAction,
   updateGeoBlockSettingsAction,
+  updateErrorPagesSettingsAction,
 } from "./actions";
 import { cn } from "@/lib/utils";
 
@@ -94,6 +97,7 @@ const SETTINGS_GROUPS: SettingsGroup[] = [
     label: "Security",
     items: [
       { id: "geoblock", name: "Global Geoblocking", desc: "Default geoblock rules across all hosts", icon: <MapPin className="h-4 w-4" /> },
+      { id: "error-pages", name: "Error Pages", desc: "Global custom error responses (fallback for all hosts)", icon: <FileWarning className="h-4 w-4" /> },
       { id: "authentik", name: "Authentik Defaults", desc: "Forward-auth defaults for new proxy hosts", icon: <UserCheck className="h-4 w-4" /> },
       { id: "oauth", name: "OAuth Providers", desc: "OAuth/OIDC SSO providers", icon: <KeyRound className="h-4 w-4" /> },
     ],
@@ -376,6 +380,7 @@ type Props = {
   dns: DnsSettings | null;
   upstreamDnsResolution: UpstreamDnsResolutionSettings | null;
   globalGeoBlock?: GeoBlockSettings | null;
+  globalErrorPages?: ErrorPagesSettings | null;
   oauthProviders: OAuthProvider[];
   baseUrl: string;
   instanceSync: {
@@ -425,6 +430,7 @@ export default function SettingsClient({
   dns,
   upstreamDnsResolution,
   globalGeoBlock,
+  globalErrorPages,
   oauthProviders,
   baseUrl,
   instanceSync,
@@ -461,6 +467,7 @@ export default function SettingsClient({
   const [slaveInstanceState, slaveInstanceFormAction] = useActionState(createSlaveInstanceAction, null);
   const [syncState, syncFormAction] = useActionState(syncSlaveInstancesAction, null);
   const [geoBlockState, geoBlockFormAction] = useActionState(updateGeoBlockSettingsAction, null);
+  const [errorPagesState, errorPagesFormAction] = useActionState(updateErrorPagesSettingsAction, null);
 
   const isSlave = instanceSync.mode === "slave";
   const isMaster = instanceSync.mode === "master";
@@ -561,6 +568,13 @@ export default function SettingsClient({
                   globalGeoBlock={globalGeoBlock}
                   geoBlockState={geoBlockState}
                   geoBlockFormAction={geoBlockFormAction}
+                />
+              )}
+              {active === "error-pages" && (
+                <ErrorPagesSection
+                  globalErrorPages={globalErrorPages}
+                  errorPagesState={errorPagesState}
+                  errorPagesFormAction={errorPagesFormAction}
                 />
               )}
               {active === "authentik" && (
@@ -1252,6 +1266,36 @@ function GeoBlockSection({
         />
         <div className="flex justify-end">
           <Button type="submit" size="sm">Save geoblocking settings</Button>
+        </div>
+      </form>
+    </FormCard>
+  );
+}
+
+// ─── Section: Error Pages ────────────────────────────────────────────────────
+
+function ErrorPagesSection({
+  globalErrorPages,
+  errorPagesState,
+  errorPagesFormAction,
+}: {
+  globalErrorPages?: ErrorPagesSettings | null;
+  errorPagesState: { success: boolean; message?: string } | null;
+  errorPagesFormAction: (payload: FormData) => void;
+}) {
+  return (
+    <FormCard>
+      <form action={errorPagesFormAction} className="flex flex-col gap-3">
+        {errorPagesState?.message && (
+          <StatusAlert message={errorPagesState.message} success={errorPagesState.success} />
+        )}
+        <p className="text-sm text-muted-foreground">
+          These error pages apply to every proxy host as a fallback. A per-host error page for the
+          same status code takes precedence.
+        </p>
+        <ErrorPagesFields initialData={globalErrorPages?.rules ?? []} />
+        <div className="flex justify-end">
+          <Button type="submit" size="sm">Save error pages</Button>
         </div>
       </form>
     </FormCard>

--- a/app/(dashboard)/settings/actions.ts
+++ b/app/(dashboard)/settings/actions.ts
@@ -5,8 +5,8 @@ import { requireAdmin } from "@/src/lib/auth";
 import { applyCaddyConfig } from "@/src/lib/caddy";
 import { getInstanceMode, getSlaveMasterToken, setInstanceMode, setSlaveMasterToken, syncInstances } from "@/src/lib/instance-sync";
 import { createInstance, deleteInstance, updateInstance } from "@/src/lib/models/instances";
-import { clearSetting, getSetting, saveCloudflareSettings, getDnsProviderSettings, saveDnsProviderSettings, saveGeneralSettings, saveAuthentikSettings, saveMetricsSettings, saveLoggingSettings, saveDnsSettings, saveUpstreamDnsResolutionSettings, saveGeoBlockSettings, saveWafSettings, getWafSettings } from "@/src/lib/settings";
-import { listProxyHosts, updateProxyHost } from "@/src/lib/models/proxy-hosts";
+import { clearSetting, getSetting, saveCloudflareSettings, getDnsProviderSettings, saveDnsProviderSettings, saveGeneralSettings, saveAuthentikSettings, saveMetricsSettings, saveLoggingSettings, saveDnsSettings, saveUpstreamDnsResolutionSettings, saveGeoBlockSettings, saveWafSettings, getWafSettings, saveErrorPagesSettings } from "@/src/lib/settings";
+import { listProxyHosts, updateProxyHost, sanitizeErrorPageRules } from "@/src/lib/models/proxy-hosts";
 import { getWafRuleMessages } from "@/src/lib/models/waf-events";
 import type { CloudflareSettings, DnsProviderSettings, GeoBlockSettings, WafSettings } from "@/src/lib/settings";
 import { getProviderDefinition, encryptProviderCredentials } from "@/src/lib/dns-providers";
@@ -713,6 +713,39 @@ export async function updateGeoBlockSettingsAction(_prevState: ActionResult | nu
   } catch (error) {
     console.error("Failed to save geoblocking settings:", error);
     return { success: false, message: error instanceof Error ? error.message : "Failed to save geoblocking settings" };
+  }
+}
+
+export async function updateErrorPagesSettingsAction(_prevState: ActionResult | null, formData: FormData): Promise<ActionResult> {
+  try {
+    await requireAdmin();
+
+    const raw = formData.get("errorPagesJson");
+    let rules: ReturnType<typeof sanitizeErrorPageRules> = [];
+    if (raw && typeof raw === "string") {
+      try {
+        rules = sanitizeErrorPageRules(JSON.parse(raw));
+      } catch {
+        return { success: false, message: "Invalid error pages payload" };
+      }
+    }
+
+    await saveErrorPagesSettings({ rules });
+
+    try {
+      await applyCaddyConfig();
+      revalidatePath("/settings");
+      return { success: true, message: "Error pages saved and applied successfully" };
+    } catch (error) {
+      console.error("Failed to apply Caddy config:", error);
+      revalidatePath("/settings");
+      const errorMsg = error instanceof Error ? error.message : "Unknown error";
+      await syncInstances();
+      return { success: true, message: `Settings saved, but could not apply to Caddy: ${errorMsg}` };
+    }
+  } catch (error) {
+    console.error("Failed to save error pages settings:", error);
+    return { success: false, message: error instanceof Error ? error.message : "Failed to save error pages settings" };
   }
 }
 

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,5 @@
 import SettingsClient from "./SettingsClient";
-import { getGeneralSettings, getAuthentikSettings, getMetricsSettings, getLoggingSettings, getDnsSettings, getDnsProviderSettings, getSetting, getUpstreamDnsResolutionSettings, getGeoBlockSettings } from "@/src/lib/settings";
+import { getGeneralSettings, getAuthentikSettings, getMetricsSettings, getLoggingSettings, getDnsSettings, getDnsProviderSettings, getSetting, getUpstreamDnsResolutionSettings, getGeoBlockSettings, getErrorPagesSettings } from "@/src/lib/settings";
 import { getInstanceMode, getSlaveLastSync, getSlaveMasterToken, isInstanceModeFromEnv, isSyncTokenFromEnv, getEnvSlaveInstances } from "@/src/lib/instance-sync";
 import { listInstances } from "@/src/lib/models/instances";
 import { listOAuthProviders } from "@/src/lib/models/oauth-providers";
@@ -14,7 +14,7 @@ export default async function SettingsPage() {
   const modeFromEnv = isInstanceModeFromEnv();
   const tokenFromEnv = isSyncTokenFromEnv();
 
-  const [general, dnsProvider, authentik, metrics, logging, dns, upstreamDnsResolution, instanceMode, globalGeoBlock, oauthProviders] = await Promise.all([
+  const [general, dnsProvider, authentik, metrics, logging, dns, upstreamDnsResolution, instanceMode, globalGeoBlock, globalErrorPages, oauthProviders] = await Promise.all([
     getGeneralSettings(),
     getDnsProviderSettings(),
     getAuthentikSettings(),
@@ -24,6 +24,7 @@ export default async function SettingsPage() {
     getUpstreamDnsResolutionSettings(),
     getInstanceMode(),
     getGeoBlockSettings(),
+    getErrorPagesSettings(),
     listOAuthProviders(),
   ]);
 
@@ -58,6 +59,7 @@ export default async function SettingsPage() {
       dns={dns}
       upstreamDnsResolution={upstreamDnsResolution}
       globalGeoBlock={globalGeoBlock}
+      globalErrorPages={globalErrorPages}
       oauthProviders={oauthProviders}
       baseUrl={config.baseUrl}
       instanceSync={{

--- a/app/api/v1/settings/[group]/route.ts
+++ b/app/api/v1/settings/[group]/route.ts
@@ -11,6 +11,7 @@ import {
   getUpstreamDnsResolutionSettings, saveUpstreamDnsResolutionSettings,
   getGeoBlockSettings, saveGeoBlockSettings,
   getWafSettings, saveWafSettings,
+  getErrorPagesSettings, saveErrorPagesSettings,
 } from "@/src/lib/settings";
 import { getInstanceMode, setInstanceMode, getSlaveMasterToken, setSlaveMasterToken } from "@/src/lib/instance-sync";
 import { applyCaddyConfig } from "@/src/lib/caddy";
@@ -32,6 +33,7 @@ const SETTINGS_HANDLERS: Record<string, SettingsHandler> = {
   "upstream-dns": { get: getUpstreamDnsResolutionSettings, save: saveUpstreamDnsResolutionSettings as (data: never) => Promise<void>, applyCaddy: true },
   geoblock: { get: getGeoBlockSettings, save: saveGeoBlockSettings as (data: never) => Promise<void>, applyCaddy: true },
   waf: { get: getWafSettings, save: saveWafSettings as (data: never) => Promise<void>, applyCaddy: true },
+  "error-pages": { get: getErrorPagesSettings, save: saveErrorPagesSettings as (data: never) => Promise<void>, applyCaddy: true },
 };
 
 export async function GET(

--- a/src/components/proxy-hosts/ErrorPagesFields.tsx
+++ b/src/components/proxy-hosts/ErrorPagesFields.tsx
@@ -1,0 +1,113 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Trash2, Plus } from "lucide-react";
+import type { ErrorPageRule } from "@/lib/models/proxy-hosts";
+
+type RuleState = { statuses: string; body: string; contentType: string };
+
+function toState(rules: ErrorPageRule[]): RuleState[] {
+  return rules.map((r) => ({
+    statuses: r.statuses.join(", "),
+    body: r.body,
+    contentType: r.contentType ?? "",
+  }));
+}
+
+function parseStatuses(value: string): number[] {
+  return [
+    ...new Set(
+      value
+        .split(",")
+        .map((part) => parseInt(part.trim(), 10))
+        .filter((n) => Number.isInteger(n) && n >= 400 && n <= 599)
+    ),
+  ];
+}
+
+function toJson(rules: RuleState[]): string {
+  return JSON.stringify(
+    rules
+      .filter((r) => r.body.trim())
+      .map((r) => {
+        const out: ErrorPageRule = { statuses: parseStatuses(r.statuses), body: r.body };
+        if (r.contentType.trim()) out.contentType = r.contentType.trim();
+        return out;
+      })
+  );
+}
+
+type Props = {
+  initialData?: ErrorPageRule[];
+  // The form field name to emit. Lets the same editor back the per-host form and
+  // the global settings form.
+  name?: string;
+};
+
+export function ErrorPagesFields({ initialData = [], name = "errorPagesJson" }: Props) {
+  const [rules, setRules] = useState<RuleState[]>(toState(initialData));
+
+  const addRule = () =>
+    setRules((r) => [...r, { statuses: "502, 503, 504", body: "<h1>Service temporarily unavailable</h1>", contentType: "" }]);
+
+  const removeRule = (i: number) => setRules((r) => r.filter((_, idx) => idx !== i));
+
+  const updateRule = (i: number, key: keyof RuleState, value: string) =>
+    setRules((r) => r.map((rule, idx) => (idx === i ? { ...rule, [key]: value } : rule)));
+
+  return (
+    <div>
+      <p className="text-sm font-semibold mb-2">Error Pages</p>
+      <input type="hidden" name={name} value={toJson(rules)} />
+      {rules.length > 0 && (
+        <div className="mb-2 flex flex-col gap-3">
+          {rules.map((rule, i) => (
+            <div key={i} className="rounded-md border p-3 flex flex-col gap-2">
+              <div className="grid grid-cols-[1fr_1fr_40px] gap-2 items-center">
+                <Input
+                  size={1}
+                  placeholder="502, 503, 504 (blank = all errors)"
+                  value={rule.statuses}
+                  onChange={(e) => updateRule(i, "statuses", e.target.value)}
+                  className="h-8 text-sm"
+                />
+                <Input
+                  size={1}
+                  placeholder="text/html; charset=utf-8"
+                  value={rule.contentType}
+                  onChange={(e) => updateRule(i, "contentType", e.target.value)}
+                  className="h-8 text-sm"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => removeRule(i)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+              <Textarea
+                placeholder="<h1>Service temporarily unavailable</h1>"
+                value={rule.body}
+                onChange={(e) => updateRule(i, "body", e.target.value)}
+                className="text-sm font-mono min-h-20"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+      <Button type="button" variant="ghost" size="sm" onClick={addRule}>
+        <Plus className="h-4 w-4 mr-1" />
+        Add Error Page
+      </Button>
+      <p className="text-xs text-muted-foreground mt-1">
+        Serve a custom response body when a request errors (e.g. 502/503 when the upstream is down, or 404).
+        Comma-separate status codes, or leave blank to match every error. The original status code is preserved.
+      </p>
+    </div>
+  );
+}

--- a/src/components/proxy-hosts/HostDialogs.tsx
+++ b/src/components/proxy-hosts/HostDialogs.tsx
@@ -30,6 +30,7 @@ import { RewriteFields } from "./RewriteFields";
 import { PathAllowsFields } from "./PathAllowsFields";
 import { PathBlocksFields } from "./PathBlocksFields";
 import { PathRewritesFields } from "./PathRewritesFields";
+import { ErrorPagesFields } from "./ErrorPagesFields";
 import type { CaCertificate } from "@/lib/models/ca-certificates";
 import type { MtlsRole } from "@/lib/models/mtls-roles";
 import type { IssuedClientCertificate } from "@/lib/models/issued-client-certificates";
@@ -156,6 +157,7 @@ export function CreateHostDialog({
                 <PathAllowsFields initialData={initialData?.pathAllows} />
                 <PathBlocksFields initialData={initialData?.pathBlocks} />
                 <PathRewritesFields initialData={initialData?.pathRewrites} />
+                <ErrorPagesFields initialData={initialData?.errorPages} />
                 <div>
                     <label className="text-sm font-medium mb-1 block">Custom Pre-Handlers (JSON)</label>
                     <Textarea
@@ -310,6 +312,7 @@ export function EditHostDialog({
                 <PathAllowsFields initialData={host.pathAllows} />
                 <PathBlocksFields initialData={host.pathBlocks} />
                 <PathRewritesFields initialData={host.pathRewrites} />
+                <ErrorPagesFields initialData={host.errorPages} />
                 <div>
                     <label className="text-sm font-medium mb-1 block">Custom Pre-Handlers (JSON)</label>
                     <Textarea

--- a/src/lib/caddy.ts
+++ b/src/lib/caddy.ts
@@ -34,6 +34,7 @@ import {
   getUpstreamDnsResolutionSettings,
   getGeoBlockSettings,
   getWafSettings,
+  getErrorPagesSettings,
   setSetting,
   type DnsSettings,
   type UpstreamDnsAddressFamily,
@@ -51,7 +52,7 @@ import {
   proxyHosts,
   l4ProxyHosts
 } from "./db/schema";
-import { type GeoBlockMode, type WafHostConfig, type MtlsConfig, type RedirectRule, type RewriteConfig, type LocationRule, type PathAllowRule, type PathBlockRule, type PathRewriteRule } from "./models/proxy-hosts";
+import { type GeoBlockMode, type WafHostConfig, type MtlsConfig, type RedirectRule, type RewriteConfig, type LocationRule, type PathAllowRule, type PathBlockRule, type PathRewriteRule, type ErrorPageRule } from "./models/proxy-hosts";
 import { buildClientAuthentication, groupMtlsDomainsByCaSet, buildMtlsRbacSubroutes, buildFingerprintCelExpression, buildValidClientCertCelExpression, resolveAllowedFingerprints, type MtlsAccessRuleLike } from "./caddy-mtls";
 import { buildRoleFingerprintMap, buildCertFingerprintMap, buildRoleCertIdMap } from "./models/mtls-roles";
 import { getAccessRulesForHosts } from "./models/mtls-access-rules";
@@ -140,6 +141,7 @@ type ProxyHostMeta = {
   path_allows?: PathAllowRule[];
   path_blocks?: PathBlockRule[];
   path_rewrites?: PathRewriteRule[];
+  error_pages?: ErrorPageRule[];
 };
 
 type L4Meta = {
@@ -686,13 +688,43 @@ export function buildLocationReverseProxy(
   return { safePath, reverseProxyHandler };
 }
 
+// Builds a Caddy server-level error route (handle_errors equivalent) that serves a
+// custom static response while preserving the original error status code. An empty
+// `statuses` list matches every error; `hosts`, when set, scopes the route to a host.
+export function buildErrorPageRoute(rule: ErrorPageRule, hosts?: string[]): CaddyHttpRoute {
+  const matcher: Record<string, unknown> = {};
+  if (hosts && hosts.length > 0) {
+    matcher.host = hosts;
+  }
+  if (rule.statuses.length > 0) {
+    // Mirrors Caddy's documented handle_errors form, e.g. {http.error.status_code} == 404
+    matcher.expression = rule.statuses.map((s) => `{http.error.status_code} == ${s}`).join(" || ");
+  }
+  const route: CaddyHttpRoute = {
+    handle: [
+      {
+        handler: "static_response",
+        status_code: "{http.error.status_code}",
+        body: rule.body,
+        headers: { "Content-Type": [rule.contentType || "text/html; charset=utf-8"] },
+      },
+    ],
+    terminal: true,
+  };
+  if (Object.keys(matcher).length > 0) {
+    route.match = [matcher];
+  }
+  return route;
+}
+
 async function buildProxyRoutes(
   rows: ProxyHostRow[],
   accessAccounts: Map<number, AccessListEntryRow[]>,
   tlsReadyCertificates: Set<number>,
   options: BuildProxyRoutesOptions
-): Promise<CaddyHttpRoute[]> {
+): Promise<{ routes: CaddyHttpRoute[]; errorRoutes: CaddyHttpRoute[] }> {
   const routes: CaddyHttpRoute[] = [];
+  const errorRoutes: CaddyHttpRoute[] = [];
   const validClientCertExpression = buildValidClientCertCelExpression();
 
   for (const row of rows) {
@@ -1670,9 +1702,17 @@ async function buildProxyRoutes(
     }
 
     routes.push(...hostRoutes);
+
+    // Per-host error pages, scoped to this host's domains. Collected separately so
+    // they can be attached to the server-level `errors` block (handle_errors).
+    if (meta.error_pages && meta.error_pages.length > 0) {
+      for (const rule of meta.error_pages) {
+        errorRoutes.push(buildErrorPageRoute(rule, domains));
+      }
+    }
   }
 
-  return sortRoutesByHostPriority(routes);
+  return { routes: sortRoutesByHostPriority(routes), errorRoutes };
 }
 
 function buildTlsConnectionPolicies(
@@ -2360,7 +2400,7 @@ async function buildCaddyDocument() {
     mTlsOptionalAuthDomains
   );
 
-  const httpRoutes: CaddyHttpRoute[] = await buildProxyRoutes(
+  const { routes: httpRoutes, errorRoutes: hostErrorRoutes } = await buildProxyRoutes(
     proxyHostRows,
     accessMap,
     readyCertificates,
@@ -2376,6 +2416,12 @@ async function buildCaddyDocument() {
       },
     }
   );
+
+  // Server-level error routes (Caddy handle_errors): per-host rules first so they
+  // take precedence, then global rules act as a fallback for any unmatched host/status.
+  const globalErrorPages = await getErrorPagesSettings();
+  const globalErrorRoutes = (globalErrorPages?.rules ?? []).map((rule) => buildErrorPageRoute(rule));
+  const errorRoutes: CaddyHttpRoute[] = [...hostErrorRoutes, ...globalErrorRoutes];
 
   const hasTls = tlsConnectionPolicies.length > 0;
 
@@ -2400,6 +2446,8 @@ async function buildCaddyDocument() {
       // This allows Caddy to handle HTTP-01 challenges for managed certificates
       ...(tlsApp ? {} : { automatic_https: { disable: true } }),
       ...(hasTls ? { tls_connection_policies: tlsConnectionPolicies } : {}),
+      // Custom error pages (handle_errors)
+      ...(errorRoutes.length > 0 ? { errors: { routes: errorRoutes } } : {}),
       // Enable access logging if configured
       ...(loggingEnabled ? { logs: { default_logger_name: "http_access" } } : {})
     };

--- a/src/lib/instance-sync.ts
+++ b/src/lib/instance-sync.ts
@@ -18,6 +18,7 @@ export type SyncSettings = {
   upstream_dns_resolution: unknown | null;
   waf: unknown | null;
   geoblock: unknown | null;
+  error_pages: unknown | null;
 };
 
 export type SyncPayload = {
@@ -258,6 +259,7 @@ export async function buildSyncPayload(): Promise<SyncPayload> {
     upstream_dns_resolution: await getSetting("upstream_dns_resolution"),
     waf: await getSetting("waf"),
     geoblock: await getSetting("geoblock"),
+    error_pages: await getSetting("error_pages"),
   };
 
   const sanitizedAccessLists = accessListRows.map((row) => ({
@@ -432,6 +434,7 @@ export async function applySyncPayload(payload: SyncPayload) {
   await setSyncedSetting("upstream_dns_resolution", payload.settings.upstream_dns_resolution ?? null);
   await setSyncedSetting("waf", payload.settings.waf ?? null);
   await setSyncedSetting("geoblock", payload.settings.geoblock ?? null);
+  await setSyncedSetting("error_pages", payload.settings.error_pages ?? null);
 
   // better-sqlite3 is synchronous, so transaction callback must be synchronous
   db.transaction((tx) => {

--- a/src/lib/models/proxy-hosts.ts
+++ b/src/lib/models/proxy-hosts.ts
@@ -73,6 +73,16 @@ export type PathRewriteRule = {
   to: string;     // internal target URI, e.g. "/dns-query"
 };
 
+// Suggested status codes for the error-page UI. Any 4xx/5xx code is accepted by
+// the sanitizer; this list only drives the picker.
+export const ERROR_PAGE_STATUS_CODES = [400, 401, 403, 404, 408, 429, 500, 502, 503, 504] as const;
+
+export type ErrorPageRule = {
+  statuses: number[];     // error codes this rule handles, e.g. [502, 503, 504]; empty = all errors
+  body: string;           // response body (HTML/text); the original status code is preserved
+  contentType?: string;   // optional Content-Type, defaults to "text/html; charset=utf-8"
+};
+
 export type PathAllowRule = {
   path: string;   // Caddy path pattern, e.g. "/secret" — matches short-circuit the
                   // subroute (no block applies) and the request falls through to the
@@ -348,6 +358,7 @@ type ProxyHostMeta = {
   path_allows?: PathAllowRule[];
   path_blocks?: PathBlockRule[];
   path_rewrites?: PathRewriteRule[];
+  error_pages?: ErrorPageRule[];
 };
 
 export type ProxyHost = {
@@ -383,6 +394,7 @@ export type ProxyHost = {
   pathAllows: PathAllowRule[];
   pathBlocks: PathBlockRule[];
   pathRewrites: PathRewriteRule[];
+  errorPages: ErrorPageRule[];
 };
 
 export type ProxyHostInput = {
@@ -415,6 +427,7 @@ export type ProxyHostInput = {
   pathAllows?: PathAllowRule[] | null;
   pathBlocks?: PathBlockRule[] | null;
   pathRewrites?: PathRewriteRule[] | null;
+  errorPages?: ErrorPageRule[] | null;
 };
 
 type ProxyHostRow = typeof proxyHosts.$inferSelect;
@@ -850,6 +863,32 @@ function sanitizePathRewrites(value: unknown): PathRewriteRule[] {
   return valid;
 }
 
+const ERROR_PAGE_BODY_MAX = 65536;
+const ERROR_PAGE_CONTENT_TYPE_MAX = 128;
+
+export function sanitizeErrorPageRules(value: unknown): ErrorPageRule[] {
+  if (!Array.isArray(value)) return [];
+  const valid: ErrorPageRule[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const body = typeof item.body === "string" ? item.body : "";
+    if (!body) continue; // a rule with no body would do nothing
+    const rawStatuses: unknown[] = Array.isArray(item.statuses) ? item.statuses : [];
+    const statuses = [...new Set(
+      rawStatuses.filter((s): s is number =>
+        typeof s === "number" && Number.isInteger(s) && s >= 400 && s <= 599)
+    )];
+    const rule: ErrorPageRule = { statuses, body: body.slice(0, ERROR_PAGE_BODY_MAX) };
+    if (typeof item.contentType === "string") {
+      // Strip CR/LF to prevent response header injection.
+      const ct = item.contentType.replace(/[\r\n]/g, "").trim().slice(0, ERROR_PAGE_CONTENT_TYPE_MAX);
+      if (ct) rule.contentType = ct;
+    }
+    valid.push(rule);
+  }
+  return valid;
+}
+
 function sanitizeLocationRules(value: unknown): LocationRule[] {
   if (!Array.isArray(value)) return [];
   const valid: LocationRule[] = [];
@@ -895,6 +934,7 @@ function parseMeta(value: string | null): ProxyHostMeta {
       path_allows: sanitizePathAllows(parsed.path_allows),
       path_blocks: sanitizePathBlocks(parsed.path_blocks),
       path_rewrites: sanitizePathRewrites(parsed.path_rewrites),
+      error_pages: sanitizeErrorPageRules(parsed.error_pages),
     };
   } catch (error) {
     console.warn("Failed to parse proxy host meta", error);
@@ -1452,6 +1492,15 @@ function buildMeta(existing: ProxyHostMeta, input: Partial<ProxyHostInput>): str
     }
   }
 
+  if (input.errorPages !== undefined) {
+    const rules = sanitizeErrorPageRules(input.errorPages ?? []);
+    if (rules.length > 0) {
+      next.error_pages = rules;
+    } else {
+      delete next.error_pages;
+    }
+  }
+
   return serializeMeta(next);
 }
 
@@ -1794,6 +1843,7 @@ function parseProxyHost(row: ProxyHostRow): ProxyHost {
     pathAllows: meta.path_allows ?? [],
     pathBlocks: meta.path_blocks ?? [],
     pathRewrites: meta.path_rewrites ?? [],
+    errorPages: meta.error_pages ?? [],
   };
 }
 
@@ -1942,6 +1992,7 @@ export async function updateProxyHost(id: number, input: Partial<ProxyHostInput>
     ...(existing.pathAllows && existing.pathAllows.length > 0 ? { path_allows: existing.pathAllows } : {}),
     ...(existing.pathBlocks && existing.pathBlocks.length > 0 ? { path_blocks: existing.pathBlocks } : {}),
     ...(existing.pathRewrites && existing.pathRewrites.length > 0 ? { path_rewrites: existing.pathRewrites } : {}),
+    ...(existing.errorPages && existing.errorPages.length > 0 ? { error_pages: existing.errorPages } : {}),
   };
   const meta = buildMeta(existingMeta, input);
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,6 +1,7 @@
 import db, { nowIso } from "./db";
 import { settings } from "./db/schema";
 import { eq } from "drizzle-orm";
+import { sanitizeErrorPageRules, type ErrorPageRule } from "./models/proxy-hosts";
 
 export type SettingValue<T> = T | null;
 
@@ -251,4 +252,18 @@ export async function getWafSettings(): Promise<WafSettings | null> {
 
 export async function saveWafSettings(s: WafSettings): Promise<void> {
   await setSetting("waf", s);
+}
+
+// Global error pages, applied as fallback error routes across every proxy host.
+// Per-host error pages take precedence over these.
+export type ErrorPagesSettings = {
+  rules: ErrorPageRule[];
+};
+
+export async function getErrorPagesSettings(): Promise<ErrorPagesSettings | null> {
+  return await getEffectiveSetting<ErrorPagesSettings>("error_pages");
+}
+
+export async function saveErrorPagesSettings(s: ErrorPagesSettings): Promise<void> {
+  await setSetting("error_pages", { rules: sanitizeErrorPageRules(s?.rules) });
 }

--- a/tests/e2e/functional/error-pages.spec.ts
+++ b/tests/e2e/functional/error-pages.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Functional tests: custom error pages (Caddy handle_errors).
+ *
+ * These exercise the real error path that the "Custom Reverse Proxy (JSON)" /
+ * "Custom Pre-Handlers (JSON)" fields could NOT reach (issue #168): a server-level
+ * error route that fires when a handler raises an error — most importantly a
+ * reverse_proxy dial failure when the upstream is down (502).
+ *
+ * Hosts are pointed at `whoami-server:9999` — the whoami container resolves, but
+ * nothing listens on :9999, so every request fails to dial and Caddy raises a 502,
+ * which is what triggers the error route. A healthy host (whoami-server:80) is used
+ * to prove error pages don't touch successful responses.
+ *
+ * Coverage:
+ *   - Per-host page served on a down upstream, with the original status preserved.
+ *   - Default and custom Content-Type.
+ *   - Status matching: a [502] rule fires on a 502, a [404] rule does not.
+ *   - Empty status list = catch-all (matches any error).
+ *   - Healthy upstream is unaffected.
+ *   - Global page as a fallback when a host defines none.
+ *   - Per-host page takes precedence over the global one.
+ */
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { httpGet, waitForRoute, waitForBody } from '../../helpers/http';
+
+const BASE_URL = 'http://localhost:3000';
+const API = `${BASE_URL}/api/v1`;
+const DEAD_UPSTREAM = 'whoami-server:9999';   // resolves, refuses → reverse_proxy 502
+const HEALTHY_UPSTREAM = 'whoami-server:80';
+
+type ErrorPageRule = { statuses: number[]; body: string; contentType?: string };
+
+async function createHost(
+  page: Page,
+  name: string,
+  domain: string,
+  upstream: string,
+  errorPages?: ErrorPageRule[],
+): Promise<number> {
+  const res = await page.request.post(`${API}/proxy-hosts`, {
+    data: {
+      name,
+      domains: [domain],
+      upstreams: [upstream],
+      sslForced: false,
+      ...(errorPages ? { errorPages } : {}),
+    },
+    headers: { 'Content-Type': 'application/json', Origin: BASE_URL },
+  });
+  expect(res.status()).toBe(201);
+  return (await res.json()).id as number;
+}
+
+async function deleteHosts(page: Page, ids: number[]): Promise<void> {
+  for (const id of ids) {
+    const res = await page.request.delete(`${API}/proxy-hosts/${id}`, {
+      headers: { Origin: BASE_URL },
+    });
+    expect(res.status()).toBe(200);
+  }
+}
+
+async function setGlobalErrorPages(page: Page, rules: ErrorPageRule[]): Promise<void> {
+  const res = await page.request.put(`${API}/settings/error-pages`, {
+    data: { rules },
+    headers: { 'Content-Type': 'application/json', Origin: BASE_URL },
+  });
+  expect(res.status()).toBe(200);
+}
+
+test.describe.serial('Custom error pages — per host', () => {
+  const hostIds: number[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    // Ensure no global error pages bleed in from another spec or block.
+    const page = await browser.newPage();
+    await setGlobalErrorPages(page, []);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await deleteHosts(page, hostIds);
+    await page.close();
+  });
+
+  test('serves a custom page (default text/html) when the upstream is down', async ({ page }) => {
+    const domain = 'func-err-basic.test';
+    hostIds.push(await createHost(page, 'Error Pages — basic 502', domain, DEAD_UPSTREAM, [
+      { statuses: [502, 503, 504], body: '<h1>Maintenance — be right back</h1>' },
+    ]));
+
+    await waitForBody(domain, 'Maintenance — be right back');
+
+    const res = await httpGet(domain);
+    // The original error status code must be preserved, not replaced with 200.
+    expect(res.status).toBe(502);
+    expect(res.body).toContain('<h1>Maintenance — be right back</h1>');
+    // No contentType configured → defaults to text/html.
+    expect(String(res.headers['content-type'])).toContain('text/html');
+  });
+
+  test('selects the rule matching the actual status and skips non-matching rules', async ({ page }) => {
+    const domain = 'func-err-select.test';
+    // First rule targets 404 (must NOT fire on a 502), second targets 502 (must fire).
+    hostIds.push(await createHost(page, 'Error Pages — status select', domain, DEAD_UPSTREAM, [
+      { statuses: [404], body: 'PAGE_FOR_404' },
+      { statuses: [502], body: 'PAGE_FOR_502' },
+    ]));
+
+    await waitForBody(domain, 'PAGE_FOR_502');
+
+    const res = await httpGet(domain);
+    expect(res.status).toBe(502);
+    expect(res.body).toContain('PAGE_FOR_502');
+    expect(res.body).not.toContain('PAGE_FOR_404');
+  });
+
+  test('an empty status list matches any error (catch-all) and honors a custom Content-Type', async ({ page }) => {
+    const domain = 'func-err-catchall.test';
+    hostIds.push(await createHost(page, 'Error Pages — catch-all', domain, DEAD_UPSTREAM, [
+      { statuses: [], body: 'CATCH_ALL_ERROR', contentType: 'text/plain; charset=utf-8' },
+    ]));
+
+    await waitForBody(domain, 'CATCH_ALL_ERROR');
+
+    const res = await httpGet(domain);
+    expect(res.status).toBe(502);
+    expect(res.body).toContain('CATCH_ALL_ERROR');
+    expect(String(res.headers['content-type'])).toBe('text/plain; charset=utf-8');
+  });
+
+  test('does not interfere with a healthy upstream', async ({ page }) => {
+    const domain = 'func-err-healthy.test';
+    hostIds.push(await createHost(page, 'Error Pages — healthy', domain, HEALTHY_UPSTREAM, [
+      { statuses: [], body: 'SHOULD_NOT_APPEAR' },
+    ]));
+
+    await waitForRoute(domain);
+
+    const res = await httpGet(domain);
+    expect(res.status).toBe(200);
+    // whoami echoes request info on success; the error body must never appear.
+    expect(res.body).toContain('Hostname');
+    expect(res.body).not.toContain('SHOULD_NOT_APPEAR');
+  });
+});
+
+test.describe.serial('Custom error pages — global + precedence', () => {
+  const hostIds: number[] = [];
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await setGlobalErrorPages(page, [{ statuses: [], body: 'GLOBAL_ERROR_PAGE' }]);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await deleteHosts(page, hostIds);
+    await setGlobalErrorPages(page, []); // reset so other specs aren't affected
+    await page.close();
+  });
+
+  test('falls back to the global error page when a host defines none', async ({ page }) => {
+    const domain = 'func-err-global.test';
+    hostIds.push(await createHost(page, 'Error Pages — global fallback', domain, DEAD_UPSTREAM));
+
+    await waitForBody(domain, 'GLOBAL_ERROR_PAGE');
+
+    const res = await httpGet(domain);
+    expect(res.status).toBe(502);
+    expect(res.body).toContain('GLOBAL_ERROR_PAGE');
+  });
+
+  test('per-host error page takes precedence over the global one', async ({ page }) => {
+    const domain = 'func-err-override.test';
+    hostIds.push(await createHost(page, 'Error Pages — per-host override', domain, DEAD_UPSTREAM, [
+      { statuses: [], body: 'HOST_OVERRIDE_PAGE' },
+    ]));
+
+    await waitForBody(domain, 'HOST_OVERRIDE_PAGE');
+
+    const res = await httpGet(domain);
+    expect(res.status).toBe(502);
+    expect(res.body).toContain('HOST_OVERRIDE_PAGE');
+    expect(res.body).not.toContain('GLOBAL_ERROR_PAGE');
+  });
+});

--- a/tests/helpers/http.ts
+++ b/tests/helpers/http.ts
@@ -78,6 +78,35 @@ export async function waitForStatus(domain: string, expectedStatus: number, time
   throw new Error(`Route for "${domain}" did not return ${expectedStatus} after ${timeoutMs}ms (last status: ${lastStatus})`);
 }
 
+/**
+ * Poll until the response body for a route contains the given substring.
+ *
+ * Needed for error-page tests: when the upstream is down the status stays 502
+ * both before the config reload (default Caddy body) and after (custom body),
+ * so waiting on status alone can't tell the config has applied — wait on the
+ * body instead.
+ */
+export async function waitForBody(domain: string, substring: string, path = '/', timeoutMs = 25_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = 0;
+  let lastBody = '';
+  while (Date.now() < deadline) {
+    try {
+      const res = await httpGet(domain, path);
+      lastStatus = res.status;
+      lastBody = res.body;
+      if (res.body.includes(substring)) return;
+    } catch {
+      // Connection refused — Caddy not ready yet
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  throw new Error(
+    `Body for "${domain}${path}" never contained "${substring}" within ${timeoutMs}ms ` +
+    `(last status: ${lastStatus}, body: ${JSON.stringify(lastBody.slice(0, 200))})`
+  );
+}
+
 /** Inject hidden form fields into #create-host-form before submitting. */
 export async function injectFormFields(page: Page, fields: Record<string, string>): Promise<void> {
   await page.evaluate((f) => {

--- a/tests/integration/instance-sync.test.ts
+++ b/tests/integration/instance-sync.test.ts
@@ -274,6 +274,7 @@ describe('applySyncPayload', () => {
         upstream_dns_resolution: null,
         waf: null,
         geoblock: null,
+        error_pages: null,
       },
       data: {
         certificates: [],

--- a/tests/unit/api-routes/settings.test.ts
+++ b/tests/unit/api-routes/settings.test.ts
@@ -21,6 +21,8 @@ vi.mock('@/src/lib/settings', () => ({
   saveGeoBlockSettings: vi.fn(),
   getWafSettings: vi.fn(),
   saveWafSettings: vi.fn(),
+  getErrorPagesSettings: vi.fn(),
+  saveErrorPagesSettings: vi.fn(),
 }));
 
 vi.mock('@/src/lib/instance-sync', () => ({

--- a/tests/unit/caddy-error-pages.test.ts
+++ b/tests/unit/caddy-error-pages.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for error-page support: the buildErrorPageRoute config builder
+ * (src/lib/caddy.ts) and the sanitizeErrorPageRules input sanitizer
+ * (src/lib/models/proxy-hosts.ts).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.unmock('@/src/lib/caddy');
+
+import { buildErrorPageRoute } from '@/src/lib/caddy';
+import { sanitizeErrorPageRules } from '@/src/lib/models/proxy-hosts';
+
+describe('buildErrorPageRoute', () => {
+  it('builds a per-host route with host matcher and status expression', () => {
+    const route = buildErrorPageRoute(
+      { statuses: [502, 503], body: '<h1>down</h1>' },
+      ['a.example.com', 'b.example.com']
+    );
+
+    expect(route.match).toEqual([
+      {
+        host: ['a.example.com', 'b.example.com'],
+        expression: '{http.error.status_code} == 502 || {http.error.status_code} == 503',
+      },
+    ]);
+    expect(route.terminal).toBe(true);
+    expect(route.handle).toEqual([
+      {
+        handler: 'static_response',
+        status_code: '{http.error.status_code}',
+        body: '<h1>down</h1>',
+        headers: { 'Content-Type': ['text/html; charset=utf-8'] },
+      },
+    ]);
+  });
+
+  it('omits the match block entirely for a global catch-all rule', () => {
+    const route = buildErrorPageRoute({ statuses: [], body: 'oops' });
+    expect(route.match).toBeUndefined();
+    expect(route.handle).toBeDefined();
+  });
+
+  it('matches host only when statuses is empty but a host is given', () => {
+    const route = buildErrorPageRoute({ statuses: [], body: 'oops' }, ['x.example.com']);
+    expect(route.match).toEqual([{ host: ['x.example.com'] }]);
+  });
+
+  it('uses a single comparison for one status code', () => {
+    const route = buildErrorPageRoute({ statuses: [404], body: 'nope' });
+    expect(route.match).toEqual([{ expression: '{http.error.status_code} == 404' }]);
+  });
+
+  it('honors a custom content type', () => {
+    const route = buildErrorPageRoute({ statuses: [], body: '{}', contentType: 'application/json' });
+    const handle = (route.handle as Array<Record<string, unknown>>)[0];
+    expect(handle.headers).toEqual({ 'Content-Type': ['application/json'] });
+  });
+});
+
+describe('sanitizeErrorPageRules', () => {
+  it('drops rules without a body', () => {
+    expect(sanitizeErrorPageRules([{ statuses: [502], body: '' }])).toEqual([]);
+    expect(sanitizeErrorPageRules([{ statuses: [502] }])).toEqual([]);
+  });
+
+  it('filters out-of-range and non-integer status codes and dedupes', () => {
+    const [rule] = sanitizeErrorPageRules([
+      { statuses: [502, 502, 99, 700, 503.5, 404], body: 'x' },
+    ]);
+    expect(rule.statuses).toEqual([502, 404]);
+  });
+
+  it('defaults to empty statuses (all errors) when not an array', () => {
+    const [rule] = sanitizeErrorPageRules([{ statuses: 'nope', body: 'x' }]);
+    expect(rule.statuses).toEqual([]);
+  });
+
+  it('strips CR/LF from contentType to prevent header injection', () => {
+    const [rule] = sanitizeErrorPageRules([
+      { statuses: [], body: 'x', contentType: 'text/html\r\nX-Evil: 1' },
+    ]);
+    expect(rule.contentType).toBe('text/htmlX-Evil: 1');
+  });
+
+  it('returns [] for non-array input', () => {
+    expect(sanitizeErrorPageRules(null)).toEqual([]);
+    expect(sanitizeErrorPageRules('foo')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for custom error pages in Caddy, allowing users to serve custom response bodies when requests fail (e.g., 502/503 when upstream is down, or 404). Error pages can be configured per-host or globally as a fallback.

- **Per-host error pages**: Each proxy host can define rules matching specific HTTP error codes (or all errors) with custom HTML/text responses
- **Global error pages**: Settings page allows defining global error page rules that apply to all hosts as a fallback
- **Precedence**: Per-host rules take precedence over global rules
- **Status preservation**: Original error status codes are preserved in responses
- **Caddy integration**: Implemented via `handle_errors` server-level routes with host and status matchers

## Type of change

- [x] New feature
- [x] Tests

## Testing

- [x] I ran relevant automated tests
- [x] I updated or added tests

Test details:

```text
Unit tests (tests/unit/caddy-error-pages.test.ts):
- buildErrorPageRoute: Validates route construction with host matchers, status expressions, custom Content-Type
- sanitizeErrorPageRules: Validates input sanitization (body filtering, status code validation, header injection prevention)

E2E tests (tests/e2e/functional/error-pages.spec.ts):
- Per-host error pages served on dead upstream (502) with status preservation
- Status code matching (502 rule fires on 502, 404 rule does not)
- Catch-all rules (empty status list matches any error)
- Custom Content-Type headers
- Healthy upstreams unaffected by error page rules
- Global error pages as fallback
- Per-host precedence over global rules

All tests pass with Caddy integration verified.
```

## Security and operations impact

- **Input validation**: Error page bodies limited to 65KB, Content-Type headers sanitized to prevent CR/LF injection
- **Caddy config**: New `handle_errors` block added to server config with per-host and global error routes
- **No breaking changes**: Existing proxy hosts continue to work; error pages are optional
- **Instance sync**: Error pages settings included in master/slave sync payload

## Checklist

- [x] I have searched for related issues or pull requests.
- [x] I have kept this pull request focused on one logical change.
- [x] I have updated documentation where needed.
- [x] I have not included secrets, credentials, private keys, or unrelated local files.