### PR TITLE
Disable ClickHouse internal system logs to cut idle disk writes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,11 @@ services:
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     volumes:
       - clickhouse-data:/var/lib/clickhouse
-      - ./docker/clickhouse/config.d:/etc/clickhouse-server/config.d:ro
+      # Mount only our single override file, not the whole config.d directory.
+      # Bind-mounting the directory would shadow the image's docker_related_config.xml
+      # (which sets listen_host to ::/0.0.0.0), leaving ClickHouse bound to loopback
+      # only so the web container could no longer reach it.
+      - ./docker/clickhouse/config.d/low-disk-write.xml:/etc/clickhouse-server/config.d/low-disk-write.xml:ro
     networks:
       - caddy-network
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,6 +183,7 @@ services:
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     volumes:
       - clickhouse-data:/var/lib/clickhouse
+      - ./docker/clickhouse/config.d:/etc/clickhouse-server/config.d:ro
     networks:
       - caddy-network
     healthcheck:

--- a/docker/clickhouse/config.d/low-disk-write.xml
+++ b/docker/clickhouse/config.d/low-disk-write.xml
@@ -12,6 +12,7 @@
 <clickhouse>
     <asynchronous_metric_log remove="1"/>
     <metric_log remove="1"/>
+    <histogram_metric_log remove="1"/>
     <trace_log remove="1"/>
     <query_log remove="1"/>
     <query_thread_log remove="1"/>

--- a/docker/clickhouse/config.d/low-disk-write.xml
+++ b/docker/clickhouse/config.d/low-disk-write.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+  Disables ClickHouse's internal diagnostic system-log tables.
+
+  On stock configuration these tables (metric_log / asynchronous_metric_log in
+  particular) flush every few seconds regardless of user traffic, which writes
+  several GB/day and wears out SSDs even when the proxy is idle. caddy-proxy-manager
+  never queries them, so we turn them off to keep disk writes proportional to
+  actual traffic. Remove this file (and restart ClickHouse) to restore the
+  defaults if you need them for debugging.
+-->
+<clickhouse>
+    <asynchronous_metric_log remove="1"/>
+    <metric_log remove="1"/>
+    <trace_log remove="1"/>
+    <query_log remove="1"/>
+    <query_thread_log remove="1"/>
+    <query_views_log remove="1"/>
+    <part_log remove="1"/>
+    <processors_profile_log remove="1"/>
+    <text_log remove="1"/>
+    <session_log remove="1"/>
+    <opentelemetry_span_log remove="1"/>
+    <blob_storage_log remove="1"/>
+    <backup_log remove="1"/>
+</clickhouse>

--- a/src/lib/clickhouse/client.ts
+++ b/src/lib/clickhouse/client.ts
@@ -167,6 +167,48 @@ async function ensureRetentionTtl(ch: ClickHouseClient, table: (typeof RETENTION
   });
 }
 
+// Diagnostic system-log tables that docker/clickhouse/config.d/low-disk-write.xml
+// turns off. On stock ClickHouse these flush every few seconds regardless of
+// traffic, so a deployment that ran before the override accumulated gigabytes we
+// can now reclaim. Disabling only stops new writes; the old data lingers until
+// the tables are dropped, which is what this list drives.
+const DISABLED_SYSTEM_LOGS = [
+  'metric_log',
+  'asynchronous_metric_log',
+  'trace_log',
+  'query_log',
+  'query_thread_log',
+  'query_views_log',
+  'part_log',
+  'processors_profile_log',
+  'text_log',
+  'session_log',
+  'opentelemetry_span_log',
+  'blob_storage_log',
+  'backup_log',
+] as const;
+
+/**
+ * Drop the diagnostic system-log tables we disable via config so their
+ * already-written data is reclaimed. Best-effort: the analytics user often
+ * lacks DROP on the `system` database, so a failure is logged once and ignored
+ * rather than aborting startup.
+ */
+async function dropDisabledSystemLogs(ch: ClickHouseClient): Promise<void> {
+  for (const name of DISABLED_SYSTEM_LOGS) {
+    try {
+      await ch.command({ query: `DROP TABLE IF EXISTS system.${name} SYNC` });
+    } catch (err) {
+      console.warn(
+        `[clickhouse] could not drop disabled system log tables (insufficient privileges?); ` +
+        `they will stop growing once the config override is applied, but existing data must be ` +
+        `cleared manually. Reason: ${(err as Error).message}`,
+      );
+      return;
+    }
+  }
+}
+
 export async function initClickHouse(): Promise<void> {
   if (!analyticsConfigured) {
     console.log('ClickHouse analytics disabled (CLICKHOUSE_PASSWORD not set)');
@@ -182,6 +224,7 @@ export async function initClickHouse(): Promise<void> {
   for (const table of RETENTION_TABLES) {
     await ensureRetentionTtl(ch, table);
   }
+  await dropDisabledSystemLogs(ch);
 }
 
 export async function closeClickHouse(): Promise<void> {

--- a/src/lib/clickhouse/client.ts
+++ b/src/lib/clickhouse/client.ts
@@ -186,16 +186,42 @@ const DISABLED_SYSTEM_LOGS = [
   'opentelemetry_span_log',
   'blob_storage_log',
   'backup_log',
+  'histogram_metric_log',
 ] as const;
 
+// Matches a disabled log table and its numbered upgrade leftovers. When a
+// ClickHouse upgrade changes a system-log table's schema, the server renames
+// the old table to `<name>_<N>` (e.g. trace_log_3) and creates a fresh one;
+// those frozen copies are never cleaned up and, on long-lived deployments,
+// dwarf the live table. An exact-name drop misses them, so we match the
+// `_<N>` suffix too. Anchored to full names built from the trusted constant
+// list above — no user input reaches this regex.
+const DISABLED_SYSTEM_LOG_PATTERN = `^(${DISABLED_SYSTEM_LOGS.join('|')})(_[0-9]+)?$`;
+
 /**
- * Drop the diagnostic system-log tables we disable via config so their
+ * Drop the diagnostic system-log tables we disable via config — including the
+ * numbered `_<N>` copies left behind by past version upgrades — so their
  * already-written data is reclaimed. Best-effort: the analytics user often
  * lacks DROP on the `system` database, so a failure is logged once and ignored
  * rather than aborting startup.
  */
 async function dropDisabledSystemLogs(ch: ClickHouseClient): Promise<void> {
-  for (const name of DISABLED_SYSTEM_LOGS) {
+  let names: string[];
+  try {
+    const result = await ch.query({
+      query: `SELECT name FROM system.tables WHERE database = 'system' AND match(name, {pattern:String})`,
+      query_params: { pattern: DISABLED_SYSTEM_LOG_PATTERN },
+      format: 'JSONEachRow',
+    });
+    names = (await result.json<{ name: string }>())
+      .map((row) => row.name)
+      .filter((name): name is string => typeof name === 'string' && name.length > 0);
+  } catch (err) {
+    console.warn(`[clickhouse] could not list disabled system log tables to drop: ${(err as Error).message}`);
+    return;
+  }
+
+  for (const name of names) {
     try {
       await ch.command({ query: `DROP TABLE IF EXISTS system.${name} SYNC` });
     } catch (err) {

--- a/tests/e2e/clickhouse-system-logs.spec.ts
+++ b/tests/e2e/clickhouse-system-logs.spec.ts
@@ -22,6 +22,7 @@ const DISABLED_SYSTEM_LOGS = [
   'opentelemetry_span_log',
   'blob_storage_log',
   'backup_log',
+  'histogram_metric_log',
 ] as const;
 
 // ClickHouse HTTP port is exposed to the host by tests/docker-compose.test.yml.

--- a/tests/e2e/clickhouse-system-logs.spec.ts
+++ b/tests/e2e/clickhouse-system-logs.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { createClient, type ClickHouseClient } from '@clickhouse/client';
+
+// docker/clickhouse/config.d/low-disk-write.xml is mounted into the ClickHouse
+// container by docker-compose.yml and turns these diagnostic system-log tables
+// off with remove="1". On stock ClickHouse they flush every few seconds even
+// when the proxy is idle, writing several GB/day; disabling them means the
+// tables are never created, so disk writes stay proportional to real traffic.
+// Keep this list in sync with low-disk-write.xml and DISABLED_SYSTEM_LOGS in
+// src/lib/clickhouse/client.ts.
+const DISABLED_SYSTEM_LOGS = [
+  'metric_log',
+  'asynchronous_metric_log',
+  'trace_log',
+  'query_log',
+  'query_thread_log',
+  'query_views_log',
+  'part_log',
+  'processors_profile_log',
+  'text_log',
+  'session_log',
+  'opentelemetry_span_log',
+  'blob_storage_log',
+  'backup_log',
+] as const;
+
+// ClickHouse HTTP port is exposed to the host by tests/docker-compose.test.yml.
+function makeClient(): ClickHouseClient {
+  return createClient({
+    url: 'http://localhost:8123',
+    username: 'cpm',
+    password: 'test-clickhouse-password-2026',
+    database: 'analytics',
+  });
+}
+
+test.describe('ClickHouse internal system logs disabled', () => {
+  test('none of the disabled diagnostic system-log tables exist', async () => {
+    const ch = makeClient();
+    // Table names are hard-coded safe identifiers, so an inline IN list is fine.
+    const inList = DISABLED_SYSTEM_LOGS.map((n) => `'${n}'`).join(', ');
+    try {
+      // remove="1" stops ClickHouse from ever setting up these log queues, so
+      // the tables are never created. If the override is dropped or unmounted,
+      // they reappear in system.tables and this assertion fails.
+      const result = await ch.query({
+        query: `SELECT name FROM system.tables WHERE database = 'system' AND name IN (${inList}) ORDER BY name`,
+        format: 'JSONEachRow',
+      });
+      const present = (await result.json<{ name: string }>()).map((r) => r.name);
+      expect(present, `disabled system-log tables should not exist, found: ${present.join(', ')}`).toEqual([]);
+    } finally {
+      await ch.close();
+    }
+  });
+});

--- a/tests/integration/clickhouse-client.test.ts
+++ b/tests/integration/clickhouse-client.test.ts
@@ -122,6 +122,60 @@ describe('clickhouse client analytics enablement', () => {
     await expect(import('@/src/lib/clickhouse/client')).rejects.toThrow(/CLICKHOUSE_RETENTION_DAYS/);
   });
 
+  it('drops the disabled diagnostic system-log tables on init to reclaim their data', async () => {
+    vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
+
+    const commands: string[] = [];
+    const command = vi.fn(async ({ query }: { query: string }) => { commands.push(query); });
+    const query = vi.fn(async () => ({ json: async () => [{ create_table_query: 'TTL ts + toIntervalDay(30)' }] }));
+
+    vi.doMock('@clickhouse/client', () => ({
+      createClient: vi.fn(() => ({ query, command, insert: vi.fn(), close: vi.fn() })),
+    }));
+
+    const { initClickHouse } = await import('@/src/lib/clickhouse/client');
+    await initClickHouse();
+
+    const expected = [
+      'metric_log', 'asynchronous_metric_log', 'trace_log', 'query_log', 'query_thread_log',
+      'query_views_log', 'part_log', 'processors_profile_log', 'text_log', 'session_log',
+      'opentelemetry_span_log', 'blob_storage_log', 'backup_log',
+    ];
+    for (const name of expected) {
+      expect(commands).toContain(`DROP TABLE IF EXISTS system.${name} SYNC`);
+    }
+  });
+
+  it('does not abort init when dropping system-log tables fails (insufficient privileges)', async () => {
+    vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
+
+    const dropAttempts: string[] = [];
+    const command = vi.fn(async ({ query }: { query: string }) => {
+      if (query.startsWith('DROP TABLE IF EXISTS system.')) {
+        dropAttempts.push(query);
+        throw new Error('Not enough privileges. To execute this query, it is necessary to have the grant DROP TABLE');
+      }
+    });
+    const query = vi.fn(async () => ({ json: async () => [{ create_table_query: 'TTL ts + toIntervalDay(30)' }] }));
+
+    vi.doMock('@clickhouse/client', () => ({
+      createClient: vi.fn(() => ({ query, command, insert: vi.fn(), close: vi.fn() })),
+    }));
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { initClickHouse } = await import('@/src/lib/clickhouse/client');
+    // Best-effort: a privilege error must not reject and abort startup.
+    await expect(initClickHouse()).resolves.toBeUndefined();
+
+    // Bails out after the first failure rather than spamming a warning per table.
+    expect(dropAttempts).toHaveLength(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('could not drop disabled system log tables');
+
+    warn.mockRestore();
+  });
+
   it('returns full WAF stats for the filtered result set', async () => {
     vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
 

--- a/tests/integration/clickhouse-client.test.ts
+++ b/tests/integration/clickhouse-client.test.ts
@@ -122,45 +122,69 @@ describe('clickhouse client analytics enablement', () => {
     await expect(import('@/src/lib/clickhouse/client')).rejects.toThrow(/CLICKHOUSE_RETENTION_DAYS/);
   });
 
-  it('drops the disabled diagnostic system-log tables on init to reclaim their data', async () => {
-    vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
-
-    const commands: string[] = [];
-    const command = vi.fn(async ({ query }: { query: string }) => { commands.push(query); });
-    const query = vi.fn(async () => ({ json: async () => [{ create_table_query: 'TTL ts + toIntervalDay(30)' }] }));
-
+  // The drop step first enumerates matching tables from system.tables, then drops
+  // each. This mock answers the enumeration query with `liveTables` and every
+  // other query (the retention create_table_query read) with a matching 30-day TTL.
+  function mockClient(liveTables: string[], commandImpl?: (q: string) => void) {
+    const calls: { command: string[]; queries: { query: string; params?: Record<string, unknown> }[] } = {
+      command: [],
+      queries: [],
+    };
+    const command = vi.fn(async ({ query }: { query: string }) => {
+      calls.command.push(query);
+      commandImpl?.(query);
+    });
+    const query = vi.fn(async ({ query, query_params }: { query: string; query_params?: Record<string, unknown> }) => {
+      calls.queries.push({ query, params: query_params });
+      if (query.includes('FROM system.tables') && query.includes('match(name')) {
+        return { json: async () => liveTables.map((name) => ({ name })) };
+      }
+      return { json: async () => [{ create_table_query: 'TTL ts + toIntervalDay(30)' }] };
+    });
     vi.doMock('@clickhouse/client', () => ({
       createClient: vi.fn(() => ({ query, command, insert: vi.fn(), close: vi.fn() })),
     }));
+    return calls;
+  }
+
+  it('drops every disabled system-log table that exists, including numbered upgrade leftovers', async () => {
+    vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
+
+    // What system.tables would return: live tables, numbered _N copies from past
+    // upgrades, and the newly-disabled histogram_metric_log.
+    const liveTables = ['trace_log', 'trace_log_3', 'trace_log_5', 'metric_log', 'metric_log_0', 'histogram_metric_log'];
+    const calls = mockClient(liveTables);
 
     const { initClickHouse } = await import('@/src/lib/clickhouse/client');
     await initClickHouse();
 
-    const expected = [
-      'metric_log', 'asynchronous_metric_log', 'trace_log', 'query_log', 'query_thread_log',
-      'query_views_log', 'part_log', 'processors_profile_log', 'text_log', 'session_log',
-      'opentelemetry_span_log', 'blob_storage_log', 'backup_log',
-    ];
-    for (const name of expected) {
-      expect(commands).toContain(`DROP TABLE IF EXISTS system.${name} SYNC`);
+    // The enumeration matches the disabled families plus an optional _<N> suffix,
+    // and now includes histogram_metric_log.
+    const enumeration = calls.queries.find((q) => q.query.includes('match(name'));
+    expect(enumeration?.params?.pattern).toBe(
+      '^(metric_log|asynchronous_metric_log|trace_log|query_log|query_thread_log|query_views_log|' +
+      'part_log|processors_profile_log|text_log|session_log|opentelemetry_span_log|blob_storage_log|' +
+      'backup_log|histogram_metric_log)(_[0-9]+)?$',
+    );
+
+    // Exactly the tables that exist are dropped — the _N leftovers included.
+    for (const name of liveTables) {
+      expect(calls.command).toContain(`DROP TABLE IF EXISTS system.${name} SYNC`);
     }
+    const drops = calls.command.filter((q) => q.startsWith('DROP TABLE IF EXISTS system.'));
+    expect(drops).toHaveLength(liveTables.length);
   });
 
   it('does not abort init when dropping system-log tables fails (insufficient privileges)', async () => {
     vi.stubEnv('CLICKHOUSE_PASSWORD', 'test-clickhouse-password');
 
     const dropAttempts: string[] = [];
-    const command = vi.fn(async ({ query }: { query: string }) => {
-      if (query.startsWith('DROP TABLE IF EXISTS system.')) {
-        dropAttempts.push(query);
+    const calls = mockClient(['trace_log', 'metric_log', 'part_log'], (q) => {
+      if (q.startsWith('DROP TABLE IF EXISTS system.')) {
+        dropAttempts.push(q);
         throw new Error('Not enough privileges. To execute this query, it is necessary to have the grant DROP TABLE');
       }
     });
-    const query = vi.fn(async () => ({ json: async () => [{ create_table_query: 'TTL ts + toIntervalDay(30)' }] }));
-
-    vi.doMock('@clickhouse/client', () => ({
-      createClient: vi.fn(() => ({ query, command, insert: vi.fn(), close: vi.fn() })),
-    }));
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -172,6 +196,7 @@ describe('clickhouse client analytics enablement', () => {
     expect(dropAttempts).toHaveLength(1);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain('could not drop disabled system log tables');
+    void calls;
 
     warn.mockRestore();
   });


### PR DESCRIPTION
ClickHouse's default metric_log/asynchronous_metric_log/trace_log tables
flush every few seconds regardless of traffic, writing several GB/day and
wearing out SSDs even when the proxy is idle. These diagnostic tables are
never queried by the app, so disable them via a mounted config.d override
to keep disk writes proportional to actual traffic.

Addresses discussion #170.