### PR TITLE
Use relative paths for all login/dashboard redirects

### DIFF
--- a/app/(auth)/link-account/page.tsx
+++ b/app/(auth)/link-account/page.tsx
@@ -14,14 +14,14 @@ export default async function LinkAccountPage({ searchParams }: LinkAccountPageP
 
   // Already authenticated - redirect
   if (session) {
-    redirect("/");
+    redirect(".");
   }
 
   // Get linking ID from error parameter (NextAuth redirects with error param)
   const errorParam = searchParams.error || "";
 
   if (!errorParam.startsWith("LINKING_REQUIRED:")) {
-    redirect("/login?error=Invalid linking request");
+    redirect("login?error=Invalid linking request");
   }
 
   const linkingId = errorParam.replace("LINKING_REQUIRED:", "");
@@ -31,14 +31,14 @@ export default async function LinkAccountPage({ searchParams }: LinkAccountPageP
   const rawToken = await peekLinkingToken(linkingId);
 
   if (!rawToken) {
-    redirect("/login?error=Linking token expired or invalid");
+    redirect("login?error=Linking token expired or invalid");
   }
 
   // Verify token and decode for display purposes only
   const tokenPayload = await verifyLinkingToken(rawToken);
 
   if (!tokenPayload) {
-    redirect("/login?error=Linking token expired or invalid");
+    redirect("login?error=Linking token expired or invalid");
   }
 
   // Pass only the opaque linkingId to the client — the raw JWT never leaves the server

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -6,7 +6,7 @@ import LoginClient from "./LoginClient";
 export default async function LoginPage() {
   const session = await auth();
   if (session) {
-    redirect("/");
+    redirect(".");
   }
 
   const enabledProviders = await getProviderDisplayList();

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -11,7 +11,7 @@ export default async function ProfilePage() {
 
   const user = await getUserById(userId);
   if (!user) {
-    redirect("/login");
+    redirect("login");
   }
 
   const [enabledProviders, apiTokens] = await Promise.all([

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuth } from "@/src/lib/auth-server";
 import { checkSameOrigin } from "@/src/lib/auth";
-import { config } from "@/src/lib/config";
 import { headers } from "next/headers";
 
 export const dynamic = "force-dynamic";
@@ -11,5 +10,5 @@ export async function POST(request: NextRequest) {
   if (originCheck) return originCheck;
 
   await getAuth().api.signOut({ headers: await headers() });
-  return NextResponse.redirect(new URL("/login", config.baseUrl));
+  return NextResponse.redirect(new URL("login", request.url));
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -57,7 +57,7 @@ export default async function middleware(req: NextRequest) {
 
   // Redirect unauthenticated users to login
   if (!isAuthenticated && !pathname.startsWith("/login")) {
-    const loginUrl = new URL("/login", req.url);
+    const loginUrl = new URL("login", req.url);
     return NextResponse.redirect(loginUrl);
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -89,7 +89,7 @@ export async function requireUser(): Promise<Session> {
   const session = await auth();
   if (!session?.user) {
     const { redirect } = await import("next/navigation");
-    redirect("/login");
+    redirect("login");
     throw new Error("Redirecting to login"); // TypeScript doesn't know redirect() never returns
   }
   return session;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                              
                                                                      
  - Replace all absolute redirect paths (`/login`, `/`) with relative equivalents (`login`, `.`) across the app                                                                                                                                                           
  - Switch the logout route from `new URL("/login", config.baseUrl)` to `new URL("login", request.url)`, removing the dependency on `BASE_URL` for this redirect
                                                                                                                                                                                                                                                                          
  ## Problem                                                          
                                                                                                             
  I'm building a Home Assistant add-on that packages Caddy Proxy Manager as a native HA add-on. Home Assistant exposes add-ons through its ingress system, which proxies all requests under a dynamic path prefix (e.g. `/app/f49fbc8c_caddy_proxy_manager/`). This prefix
   is not rewritten — the app receives requests with it intact.

  With the current code, all redirects use absolute paths like `/login` or `/`. When the browser follows a `Location: /login` header, it loses the ingress prefix entirely and lands on a 404 or the wrong page. This completely blocks the use of the HA ingress system — the app is unusable as a HA add-on without this fix.

  ## Solution

  Relative paths are resolved by the browser against the current URL, so the ingress prefix is preserved automatically with zero configuration required.

  This works because Next.js's `redirect()` passes the URL string through as-is in the `Location` header (`addPathPrefix` is a no-op for paths that don't start with `/`), and `new URL("login", req.url)` resolves relative to the current request URL.

  ## Files changed

  - `proxy.ts` — middleware redirect to login
  - `src/lib/auth.ts` — `requireUser()` fallback redirect
  - `app/api/auth/logout/route.ts` — post-logout redirect
  - `app/(dashboard)/profile/page.tsx` — missing user redirect
  - `app/(auth)/login/page.tsx` — already-authenticated redirect
  - `app/(auth)/link-account/page.tsx` — all redirects (authenticated, invalid token, expired token)

  ## Backwards compatibility

  No configuration changes required. Behavior is identical on standard deployments without a path prefix.
