### PR TITLE
feat: support BASE_PATH env var for sub-path deployments    

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,11 @@ ADMIN_PASSWORD=Your-Secure-P@ssw0rd-Here!
 # IMPORTANT: Do not include a trailing slash
 BASE_URL=http://localhost:3000
 
+# Base path prefix when the app is served under a sub-path (e.g. behind a reverse proxy).
+# Must start with / and have no trailing slash. Leave empty for root deployment.
+# Example: BASE_PATH=/caddy-manager
+# BASE_PATH=
+
 # =============================================================================
 # ROOTLESS OPERATION (OPTIONAL)
 # =============================================================================

--- a/app/(auth)/link-account/LinkAccountClient.tsx
+++ b/app/(auth)/link-account/LinkAccountClient.tsx
@@ -3,6 +3,7 @@
 import { useState, FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/src/lib/auth-client";
+import { useBasePath } from "@/src/hooks/useBasePath";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -21,6 +22,7 @@ export default function LinkAccountClient({
   linkingId
 }: LinkAccountClientProps) {
   const router = useRouter();
+  const basePath = useBasePath();
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -45,7 +47,7 @@ export default function LinkAccountClient({
         return;
       }
 
-      await authClient.signIn.social({ provider, callbackURL: "/" });
+      await authClient.signIn.social({ provider, callbackURL: `${basePath}/` });
     } catch {
       setError("An error occurred while linking your account");
       setLoading(false);
@@ -53,7 +55,7 @@ export default function LinkAccountClient({
   };
 
   const handleUsePassword = () => {
-    router.push("/login");
+    router.push(`${basePath}/login`);
   };
 
   const providerName = provider.charAt(0).toUpperCase() + provider.slice(1);

--- a/app/(auth)/link-account/page.tsx
+++ b/app/(auth)/link-account/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/src/lib/auth";
+import { config } from "@/src/lib/config";
 import { peekLinkingToken, verifyLinkingToken } from "@/src/lib/services/account-linking";
 import LinkAccountClient from "./LinkAccountClient";
 
@@ -14,14 +15,14 @@ export default async function LinkAccountPage({ searchParams }: LinkAccountPageP
 
   // Already authenticated - redirect
   if (session) {
-    redirect("/");
+    redirect(`${config.basePath}/`);
   }
 
   // Get linking ID from error parameter (NextAuth redirects with error param)
   const errorParam = searchParams.error || "";
 
   if (!errorParam.startsWith("LINKING_REQUIRED:")) {
-    redirect("/login?error=Invalid linking request");
+    redirect(`${config.basePath}/login?error=Invalid linking request`);
   }
 
   const linkingId = errorParam.replace("LINKING_REQUIRED:", "");
@@ -31,14 +32,14 @@ export default async function LinkAccountPage({ searchParams }: LinkAccountPageP
   const rawToken = await peekLinkingToken(linkingId);
 
   if (!rawToken) {
-    redirect("/login?error=Linking token expired or invalid");
+    redirect(`${config.basePath}/login?error=Linking token expired or invalid`);
   }
 
   // Verify token and decode for display purposes only
   const tokenPayload = await verifyLinkingToken(rawToken);
 
   if (!tokenPayload) {
-    redirect("/login?error=Linking token expired or invalid");
+    redirect(`${config.basePath}/login?error=Linking token expired or invalid`);
   }
 
   // Pass only the opaque linkingId to the client — the raw JWT never leaves the server

--- a/app/(auth)/login/LoginClient.tsx
+++ b/app/(auth)/login/LoginClient.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
 import { authClient } from "@/src/lib/auth-client";
+import { useBasePath } from "@/src/hooks/useBasePath";
 import { LogIn } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,6 +18,7 @@ interface LoginClientProps {
 
 export default function LoginClient({ enabledProviders = [] }: LoginClientProps) {
   const router = useRouter();
+  const basePath = useBasePath();
   const [loginError, setLoginError] = useState<string | null>(null);
   const [loginPending, setLoginPending] = useState(false);
   const [oauthPending, setOauthPending] = useState<string | null>(null);
@@ -57,7 +59,7 @@ export default function LoginClient({ enabledProviders = [] }: LoginClientProps)
       return;
     }
 
-    router.replace("/");
+    router.replace(`${basePath}/`);
     router.refresh();
   };
 
@@ -65,7 +67,7 @@ export default function LoginClient({ enabledProviders = [] }: LoginClientProps)
     setLoginError(null);
     setOauthPending(providerId);
     try {
-      await authClient.signIn.social({ provider: providerId, callbackURL: "/" });
+      await authClient.signIn.social({ provider: providerId, callbackURL: `${basePath}/` });
     } catch {
       setLoginError("Failed to sign in with OAuth");
       setOauthPending(null);

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,12 +1,13 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/src/lib/auth";
+import { config } from "@/src/lib/config";
 import { getProviderDisplayList } from "@/src/lib/models/oauth-providers";
 import LoginClient from "./LoginClient";
 
 export default async function LoginPage() {
   const session = await auth();
   if (session) {
-    redirect("/");
+    redirect(`${config.basePath}/`);
   }
 
   const enabledProviders = await getProviderDisplayList();

--- a/app/(dashboard)/DashboardLayoutClient.tsx
+++ b/app/(dashboard)/DashboardLayoutClient.tsx
@@ -15,6 +15,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { useBasePath } from "@/src/hooks/useBasePath";
 
 type User = {
   id: string;
@@ -60,6 +61,7 @@ function NavContent({ pathname, user, onNavigate }: {
   onNavigate?: () => void;
 }) {
   const router = useRouter();
+  const basePath = useBasePath();
   const isAdmin = user.role === "admin";
   const visibleItems = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
@@ -109,7 +111,7 @@ function NavContent({ pathname, user, onNavigate }: {
           <Button
             variant="ghost"
             className="flex-1 justify-start gap-3 px-2 h-auto py-2 min-w-0"
-            onClick={() => { router.push("/profile"); onNavigate?.(); }}
+            onClick={() => { router.push(`${basePath}/profile`); onNavigate?.(); }}
           >
             <Avatar className="h-8 w-8 shrink-0">
               <AvatarImage src={user.image ?? undefined} alt={user.name ?? "User"} />
@@ -146,6 +148,7 @@ export default function DashboardLayoutClient({ user, children }: { user: User; 
   const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
+  const basePath = useBasePath();
 
   return (
     <div className="flex min-h-screen">
@@ -162,7 +165,7 @@ export default function DashboardLayoutClient({ user, children }: { user: User; 
         <span className="font-semibold text-sm">Caddy Proxy Manager</span>
         <div className="flex items-center gap-1">
           <ThemeToggle />
-          <Button variant="ghost" size="icon" aria-label="Go to profile" onClick={() => router.push("/profile")}>
+          <Button variant="ghost" size="icon" aria-label="Go to profile" onClick={() => router.push(`${basePath}/profile`)}>
             <Avatar className="h-6 w-6">
               <AvatarImage src={user.image ?? undefined} />
               <AvatarFallback className="text-[10px] bg-primary text-primary-foreground">

--- a/app/(dashboard)/profile/ProfileClient.tsx
+++ b/app/(dashboard)/profile/ProfileClient.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/src/lib/auth-client";
+import { useBasePath } from "@/src/hooks/useBasePath";
 import { Camera, Check, Clock, Copy, Key, Link, LogIn, Lock, Plus, Trash2, Unlink, User, AlertTriangle } from "lucide-react";
 import type { ApiToken } from "@/lib/models/api-tokens";
 import { createApiTokenAction, deleteApiTokenAction } from "../api-tokens/actions";
@@ -40,6 +41,7 @@ interface ProfileClientProps {
 }
 
 export default function ProfileClient({ user, enabledProviders, apiTokens }: ProfileClientProps) {
+  const basePath = useBasePath();
   const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
   const [unlinkDialogOpen, setUnlinkDialogOpen] = useState(false);
   const [currentPassword, setCurrentPassword] = useState("");
@@ -158,7 +160,7 @@ export default function ProfileClient({ user, enabledProviders, apiTokens }: Pro
       }
 
       // Now initiate OAuth flow
-      await authClient.signIn.social({ provider: providerId, callbackURL: "/profile" });
+      await authClient.signIn.social({ provider: providerId, callbackURL: `${basePath}/profile` });
     } catch {
       setError("An error occurred while linking OAuth");
       setLoading(false);

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -4,6 +4,7 @@ import { getProviderDisplayList } from "@/src/lib/models/oauth-providers";
 import { listApiTokens } from "@/src/lib/models/api-tokens";
 import ProfileClient from "./ProfileClient";
 import { redirect } from "next/navigation";
+import { config } from "@/src/lib/config";
 
 export default async function ProfilePage() {
   const session = await requireUser();
@@ -11,7 +12,7 @@ export default async function ProfilePage() {
 
   const user = await getUserById(userId);
   if (!user) {
-    redirect("/login");
+    redirect(`${config.basePath}/login`);
   }
 
   const [enabledProviders, apiTokens] = await Promise.all([

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -11,5 +11,5 @@ export async function POST(request: NextRequest) {
   if (originCheck) return originCheck;
 
   await getAuth().api.signOut({ headers: await headers() });
-  return NextResponse.redirect(new URL("/login", config.baseUrl));
+  return NextResponse.redirect(new URL(`${config.basePath}/login`, config.baseUrl));
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { headers } from "next/headers";
 import "./globals.css";
 import Providers from "./providers";
+import { config } from "@/src/lib/config";
 
 function getNonce(csp: string | null): string | undefined {
   if (!csp) return undefined;
@@ -16,7 +17,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-        <Providers nonce={nonce}>{children}</Providers>
+        <Providers nonce={nonce} basePath={config.basePath}>{children}</Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,14 +4,17 @@ import { ReactNode } from "react";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { BasePathProvider } from "@/src/hooks/useBasePath";
 
-export default function Providers({ children, nonce }: { children: ReactNode; nonce?: string }) {
+export default function Providers({ children, nonce, basePath = "" }: { children: ReactNode; nonce?: string; basePath?: string }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange nonce={nonce}>
-      <TooltipProvider>
-        {children}
-      </TooltipProvider>
-      <Toaster richColors position="bottom-right" />
-    </ThemeProvider>
+    <BasePathProvider basePath={basePath}>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange nonce={nonce}>
+        <TooltipProvider>
+          {children}
+        </TooltipProvider>
+        <Toaster richColors position="bottom-right" />
+      </ThemeProvider>
+    </BasePathProvider>
   );
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -12,6 +12,7 @@ import { auth } from "@/src/lib/auth";
  */
 
 const isDev = process.env.NODE_ENV === "development";
+const BASE_PATH = (process.env.BASE_PATH ?? "").replace(/\/$/, "");
 
 /**
  * Build a nonce-based Content-Security-Policy per request.
@@ -40,13 +41,13 @@ export default async function middleware(req: NextRequest) {
 
   // Allow public routes
   if (
-    pathname === "/login" ||
-    pathname === "/portal" ||
-    pathname.startsWith("/api/auth") ||
-    pathname === "/api/health" ||
-    pathname === "/api/instances/sync" ||
-    pathname.startsWith("/api/v1/") ||
-    pathname.startsWith("/api/forward-auth/")
+    pathname === `${BASE_PATH}/login` ||
+    pathname === `${BASE_PATH}/portal` ||
+    pathname.startsWith(`${BASE_PATH}/api/auth`) ||
+    pathname === `${BASE_PATH}/api/health` ||
+    pathname === `${BASE_PATH}/api/instances/sync` ||
+    pathname.startsWith(`${BASE_PATH}/api/v1/`) ||
+    pathname.startsWith(`${BASE_PATH}/api/forward-auth/`)
   ) {
     return NextResponse.next();
   }
@@ -56,9 +57,8 @@ export default async function middleware(req: NextRequest) {
   const isAuthenticated = !!session?.user;
 
   // Redirect unauthenticated users to login
-  if (!isAuthenticated && !pathname.startsWith("/login")) {
-    const loginUrl = new URL("/login", req.url);
-    return NextResponse.redirect(loginUrl);
+  if (!isAuthenticated) {
+    return NextResponse.redirect(new URL(`${BASE_PATH}/login`, req.url));
   }
 
   // Generate per-request nonce for CSP

--- a/src/hooks/useBasePath.tsx
+++ b/src/hooks/useBasePath.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+const BasePathContext = createContext<string>("");
+
+export function BasePathProvider({ basePath, children }: { basePath: string; children: ReactNode }) {
+  return <BasePathContext.Provider value={basePath}>{children}</BasePathContext.Provider>;
+}
+
+export function useBasePath(): string {
+  return useContext(BasePathContext);
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -89,7 +89,8 @@ export async function requireUser(): Promise<Session> {
   const session = await auth();
   if (!session?.user) {
     const { redirect } = await import("next/navigation");
-    redirect("/login");
+    const { config } = await import("./config");
+    redirect(`${config.basePath}/login`);
     throw new Error("Redirecting to login"); // TypeScript doesn't know redirect() never returns
   }
   return session;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -161,6 +161,7 @@ export const config = {
   },
   caddyApiUrl: process.env.CADDY_API_URL ?? DEFAULT_CADDY_URL,
   baseUrl: process.env.BASE_URL ?? "http://localhost:3000",
+  basePath: (process.env.BASE_PATH ?? "").replace(/\/$/, ""),
   get adminUsername() {
     return getAdminCredentials().username;
   },


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                              
             
  - Add `BASE_PATH` environment variable support so the app works correctly when served under a URL prefix (e.g. Home Assistant ingress, reverse proxy sub-path)                                                                                                          
  - `BASE_PATH` is read at runtime — no rebuild required when deploying to a new prefix
  - Backwards compatible: when `BASE_PATH` is unset, all behaviour is identical to today                   
             
  ## Changes                             

  **Server-side redirects** (`proxy.ts`, `logout/route.ts`, `auth.ts`, server pages) now prefix all redirect targets with `BASE_PATH`.

  **Client-side navigation** uses a new `useBasePath()` hook backed by a React context (`BasePathProvider`) injected from the root layout server component, so `router.push()` and OAuth `callbackURL` values are correctly prefixed without requiring `NEXT_PUBLIC_*`
  build-time variables.

  **`src/lib/config`** exposes `config.basePath` for use across server-side code.

  ## Configuration

  ```bash
  # .env
  # Must start with / and have no trailing slash. Leave empty for root deployment.
  BASE_PATH=/caddy-manager

  Test plan

  - Deploy without BASE_PATH — verify all redirects and navigation work as before
  - Deploy with BASE_PATH=/caddy-manager — verify login, logout, OAuth callbacks and profile navigation all resolve under the prefix
  - TypeScript build passes: bun run build
  - Unit tests pass: bun run test

  🤖 Generated with https://claude.ai/claude-code
  ```
