### PR TITLE
ci: fix Caddy compatibility-pins workflow (compose interpolation broke verify step)

### DIFF
--- a/.github/workflows/caddy-compatibility-pins.yml
+++ b/.github/workflows/caddy-compatibility-pins.yml
@@ -33,9 +33,27 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Build the Caddy Dockerfile directly instead of `docker compose build caddy`:
+      # Compose interpolates variables for ALL services before building, and
+      # docker-compose.yml declares hard-required vars (SESSION_SECRET,
+      # ADMIN_USERNAME, ADMIN_PASSWORD, CLICKHOUSE_PASSWORD) that are unset in
+      # CI, so compose always failed here regardless of the caddy service. The
+      # Dockerfile re-runs update-compatibility-pins.sh inside the build, so
+      # this still end-to-end verifies the refreshed pins. Mirrors the caddy
+      # job of docker-build-pr.yml (same Dockerfile, same GHA cache scope).
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.changed == 'true'
+        uses: docker/setup-buildx-action@v4
+
       - name: Verify updated Caddy image
         if: steps.changes.outputs.changed == 'true'
-        run: docker compose build caddy
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/caddy/Dockerfile
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha,scope=caddy
 
       - name: Open compatibility-pin pull request
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Problem

The scheduled **Refresh Caddy compatibility pins** workflow has been failing whenever it actually detects pin changes (e.g. run [34111008771](https://github.com/fuomag9/caddy-proxy-manager/actions/runs/34111008771)):

```
error while interpolating services.web.environment.SESSION_SECRET: required variable SESSION_SECRET is missing a value
```

### Root cause

The `Verify updated Caddy image` step ran `docker compose build caddy`, but Docker Compose interpolates variables for **all services** in the file before building the requested one. `docker-compose.yml` declares hard-required variables (`${SESSION_SECRET:?...}`, `${ADMIN_USERNAME:?...}`, `${ADMIN_PASSWORD:?...}`, `${CLICKHOUSE_PASSWORD:?...}`) that are intentionally unset in CI — so compose aborted before ever building the `caddy` service, which needs none of those variables. Result: every run with actual pin changes failed, and the automation PR was never opened.

(An earlier failure on Aug 31 — `go: module github.com/caddyserver/caddy/v2: not a known dependency` — had a different cause: Dependabot's tidy wiped the `require` pins from `docker/caddy/go.mod` via #255. That was already fixed by 61b7da24 and #262 preserved the pins, so only the compose issue remains.)

## Fix

Replace the compose invocation with a direct buildx build of `docker/caddy/Dockerfile` — mirroring the `caddy` job of `docker-build-pr.yml` (same Dockerfile, same `type=gha,scope=caddy` cache):

- Compose interpolation is no longer involved at all.
- The Dockerfile re-runs `update-compatibility-pins.sh` inside the builder stage, so the image build remains a true end-to-end verification of the refreshed pins.
- `linux/amd64` only for the weekly check; dual-platform builds are already validated on every PR by `docker-build-pr.yml`.

## Validation

The exact same build (context `.`, `docker/caddy/Dockerfile`) runs green in the `build (caddy, ...)` check of this PR. After merge, the workflow can be exercised via **workflow_dispatch**; with no pending pin changes it will no-op as before.